### PR TITLE
Implement AirQuality evaluation: accept Measurement + email, create A…

### DIFF
--- a/Kvalitet_vazduha/kjar/src/main/resources/META-INF/kmodule.xml
+++ b/Kvalitet_vazduha/kjar/src/main/resources/META-INF/kmodule.xml
@@ -9,4 +9,8 @@
         <kbase name="backward-kbase" packages="backward">
         <ksession name="backward-ksession"/>
     </kbase>
+
+    <kbase name="basicRules" packages="basicRules">
+        <ksession name="basic-ksession"/>
+    </kbase>
 </kmodule>

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/META-INF/kmodule.xml
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/META-INF/kmodule.xml
@@ -11,4 +11,8 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <kbase name="backward-kbase" packages="rules/backward">
         <ksession name="backward-ksession"/>
     </kbase>
+
+    <kbase name="basicRules" packages="rules/basicRules">
+        <ksession name="basic-ksession"/>
+    </kbase>
 </kmodule>

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/airRules/air-quality-categorization.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/airRules/air-quality-categorization.drl
@@ -1,33 +1,33 @@
-package com.example.airquality.rules
+// package com.example.airquality.rules
 
-import com.example.airquality.model.PollutantMeasurement;
-import com.example.airquality.model.AirQualityStatus;
+// import com.example.airquality.model.PollutantMeasurement;
+// import com.example.airquality.model.AirQualityStatus;
 
-// Pravilo 1 – nagli porast PM2.5 u 30 minuta
-rule "Nagli porast PM2.5"
-when
-    $m1 : PollutantMeasurement($pm25 : pm25, $t1 : timestamp)
-    $m2 : PollutantMeasurement(this after[0s,30m] $m1, pm25 - $pm25 > 20)
-then
-    AirQualityStatus status = new AirQualityStatus();
-    status.setCategory(AirQualityStatus.OPASAN);
-    status.setExplanation("Nagli skok PM2.5 za više od 20 µg/m³ u 30 minuta");
-    status.setRecommendation("Ostanite unutra i obavestite institucije!");
-    insert(status);
-end
+// // Pravilo 1 – nagli porast PM2.5 u 30 minuta
+// rule "Nagli porast PM2.5"
+// when
+//     $m1 : PollutantMeasurement($pm25 : pm25, $t1 : timestamp)
+//     $m2 : PollutantMeasurement(this after[0s,30m] $m1, pm25 - $pm25 > 20)
+// then
+//     AirQualityStatus status = new AirQualityStatus();
+//     status.setCategory(AirQualityStatus.OPASAN);
+//     status.setExplanation("Nagli skok PM2.5 za više od 20 µg/m³ u 30 minuta");
+//     status.setRecommendation("Ostanite unutra i obavestite institucije!");
+//     insert(status);
+// end
 
-// Pravilo 2 – prosečan PM2.5 u poslednja 24h
-rule "Dnevni prosek PM2.5"
-when
-    accumulate(
-        $m : PollutantMeasurement( $pm25 : pm25 ) over window:time(24h),
-        $avg : average($pm25)
-    )
-    eval($avg > 35)
-then
-    AirQualityStatus status = new AirQualityStatus();
-    status.setCategory(AirQualityStatus.LOS);
-    status.setExplanation("Prosečan PM2.5 u poslednja 24h: " + $avg);
-    status.setRecommendation("Izbegavajte aktivnosti na otvorenom.");
-    insert(status);
-end
+// // Pravilo 2 – prosečan PM2.5 u poslednja 24h
+// rule "Dnevni prosek PM2.5"
+// when
+//     accumulate(
+//         $m : PollutantMeasurement( $pm25 : pm25 ) over window:time(24h),
+//         $avg : average($pm25)
+//     )
+//     eval($avg > 35)
+// then
+//     AirQualityStatus status = new AirQualityStatus();
+//     status.setCategory(AirQualityStatus.LOS);
+//     status.setExplanation("Prosečan PM2.5 u poslednja 24h: " + $avg);
+//     status.setRecommendation("Izbegavajte aktivnosti na otvorenom.");
+//     insert(status);
+// end

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/airRules/air-quality-rules.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/airRules/air-quality-rules.drl
@@ -1,253 +1,253 @@
-package rules.airRules
+// package rules.airRules
 
-import com.ftn.model.PollutantMeasurment;
-import com.ftn.model.AirQualityStatus;
-import com.ftn.model.AirQualityCategory;
-import com.ftn.model.UserProfile;
-import com.ftn.model.UserCategory;
+// import com.ftn.model.PollutantMeasurment;
+// import com.ftn.model.AirQualityStatus;
+// import com.ftn.model.AirQualityCategory;
+// import com.ftn.model.UserProfile;
+// import com.ftn.model.UserCategory;
 
-// rule "PM2.5 Kategorizacija"
+// // rule "PM2.5 Kategorizacija"
+// // when
+// //     $m : PollutantMeasurment()
+// // then
+// //     if($m.getPm25() <= 15) $m.setPm25Status(AirQualityCategory.DOBAR);
+// //     else if($m.getPm25() <= 35) $m.setPm25Status(AirQualityCategory.UMEREN);
+// //     else if($m.getPm25() <= 55) $m.setPm25Status(AirQualityCategory.LOS);
+// //     else $m.setPm25Status(AirQualityCategory.OPASAN);
+// // end
+
+// ///////////////////////////////////////
+// /// PM2.5 KATEGORIZACIJA
+// //////////////////////////////////////
+
+// rule "PM2.5 DOBAR"
 // when
-//     $m : PollutantMeasurment()
+//     $m : PollutantMeasurment(pm25 <= 15)
 // then
-//     if($m.getPm25() <= 15) $m.setPm25Status(AirQualityCategory.DOBAR);
-//     else if($m.getPm25() <= 35) $m.setPm25Status(AirQualityCategory.UMEREN);
-//     else if($m.getPm25() <= 55) $m.setPm25Status(AirQualityCategory.LOS);
-//     else $m.setPm25Status(AirQualityCategory.OPASAN);
+//     $m.setPm25Status(AirQualityCategory.DOBAR);
 // end
 
-///////////////////////////////////////
-/// PM2.5 KATEGORIZACIJA
-//////////////////////////////////////
-
-rule "PM2.5 DOBAR"
-when
-    $m : PollutantMeasurment(pm25 <= 15)
-then
-    $m.setPm25Status(AirQualityCategory.DOBAR);
-end
-
-rule "PM2.5 UMEREN"
-when
-    $m : PollutantMeasurment(pm25 > 15 && pm25 <= 35)
-then
-    $m.setPm25Status(AirQualityCategory.UMEREN);
-end
-
-rule "PM2.5 LOS"
-when
-    $m : PollutantMeasurment(pm25 > 35 && pm25 <= 55)
-then
-    $m.setPm25Status(AirQualityCategory.LOS);
-end
-
-rule "PM2.5 OPASAN"
-when
-    $m : PollutantMeasurment(pm25 > 55)
-then
-    $m.setPm25Status(AirQualityCategory.OPASAN);
-end
-
-
-// rule "PM10 Kategorizacija"
+// rule "PM2.5 UMEREN"
 // when
-//     $m : PollutantMeasurment()
+//     $m : PollutantMeasurment(pm25 > 15 && pm25 <= 35)
 // then
-//     if($m.getPm10() <= 25) $m.setPm10Status(AirQualityCategory.DOBAR);
-//     else if($m.getPm10() <= 50) $m.setPm10Status(AirQualityCategory.UMEREN);
-//     else if($m.getPm10() <= 100) $m.setPm10Status(AirQualityCategory.LOS);
-//     else $m.setPm10Status(AirQualityCategory.OPASAN);
+//     $m.setPm25Status(AirQualityCategory.UMEREN);
 // end
 
-///////////////////////////////////////
-/// PM10 KATEGORIZACIJA
-//////////////////////////////////////
-
-rule "PM10 DOBAR"
-when
-    $m : PollutantMeasurment(pm10 <= 25)
-then
-    $m.setPm10Status(AirQualityCategory.DOBAR);
-end
-
-rule "PM10 UMEREN"
-when
-    $m : PollutantMeasurment(pm10 > 25 && pm10 <= 50)
-then
-    $m.setPm10Status(AirQualityCategory.UMEREN);
-end
-
-rule "PM10 LOS"
-when
-    $m : PollutantMeasurment(pm10 > 50 && pm10 <= 100)
-then
-    $m.setPm10Status(AirQualityCategory.LOS);
-end
-
-rule "PM10 OPASAN"
-when
-    $m : PollutantMeasurment(pm10 > 100)
-then
-    $m.setPm10Status(AirQualityCategory.OPASAN);
-end
-
-// rule "NO2 Kategorizacija"
+// rule "PM2.5 LOS"
 // when
-//     $m : PollutantMeasurment()
+//     $m : PollutantMeasurment(pm25 > 35 && pm25 <= 55)
 // then
-//     if($m.getNo2() <= 40) $m.setNo2Status(AirQualityCategory.DOBAR);
-//     else if($m.getNo2() <= 90) $m.setNo2Status(AirQualityCategory.UMEREN);
-//     else if($m.getNo2() <= 180) $m.setNo2Status(AirQualityCategory.LOS);
-//     else $m.setNo2Status(AirQualityCategory.OPASAN);
+//     $m.setPm25Status(AirQualityCategory.LOS);
 // end
 
-///////////////////////////////////////
-/// NO2 KATEGORIZACIJA
-//////////////////////////////////////
+// rule "PM2.5 OPASAN"
+// when
+//     $m : PollutantMeasurment(pm25 > 55)
+// then
+//     $m.setPm25Status(AirQualityCategory.OPASAN);
+// end
 
-rule "NO2 DOBAR"
-when
-    $m : PollutantMeasurment(no2 <= 40)
-then
-    $m.setNo2Status(AirQualityCategory.DOBAR);
-end
 
-rule "NO2 UMEREN"
-when
-    $m : PollutantMeasurment(no2 > 40 && no2 <= 90)
-then
-    $m.setNo2Status(AirQualityCategory.UMEREN);
-end
+// // rule "PM10 Kategorizacija"
+// // when
+// //     $m : PollutantMeasurment()
+// // then
+// //     if($m.getPm10() <= 25) $m.setPm10Status(AirQualityCategory.DOBAR);
+// //     else if($m.getPm10() <= 50) $m.setPm10Status(AirQualityCategory.UMEREN);
+// //     else if($m.getPm10() <= 100) $m.setPm10Status(AirQualityCategory.LOS);
+// //     else $m.setPm10Status(AirQualityCategory.OPASAN);
+// // end
 
-rule "NO2 LOS"
-when
-    $m : PollutantMeasurment(no2 > 90 && no2 <= 180)
-then
-    $m.setNo2Status(AirQualityCategory.LOS);
-end
+// ///////////////////////////////////////
+// /// PM10 KATEGORIZACIJA
+// //////////////////////////////////////
 
-rule "NO2 OPASAN"
-when
-    $m : PollutantMeasurment(no2 > 180)
-then
-    $m.setNo2Status(AirQualityCategory.OPASAN);
-end
+// rule "PM10 DOBAR"
+// when
+//     $m : PollutantMeasurment(pm10 <= 25)
+// then
+//     $m.setPm10Status(AirQualityCategory.DOBAR);
+// end
 
-// rule "Kombinovanje i preporuka"
+// rule "PM10 UMEREN"
+// when
+//     $m : PollutantMeasurment(pm10 > 25 && pm10 <= 50)
+// then
+//     $m.setPm10Status(AirQualityCategory.UMEREN);
+// end
+
+// rule "PM10 LOS"
+// when
+//     $m : PollutantMeasurment(pm10 > 50 && pm10 <= 100)
+// then
+//     $m.setPm10Status(AirQualityCategory.LOS);
+// end
+
+// rule "PM10 OPASAN"
+// when
+//     $m : PollutantMeasurment(pm10 > 100)
+// then
+//     $m.setPm10Status(AirQualityCategory.OPASAN);
+// end
+
+// // rule "NO2 Kategorizacija"
+// // when
+// //     $m : PollutantMeasurment()
+// // then
+// //     if($m.getNo2() <= 40) $m.setNo2Status(AirQualityCategory.DOBAR);
+// //     else if($m.getNo2() <= 90) $m.setNo2Status(AirQualityCategory.UMEREN);
+// //     else if($m.getNo2() <= 180) $m.setNo2Status(AirQualityCategory.LOS);
+// //     else $m.setNo2Status(AirQualityCategory.OPASAN);
+// // end
+
+// ///////////////////////////////////////
+// /// NO2 KATEGORIZACIJA
+// //////////////////////////////////////
+
+// rule "NO2 DOBAR"
+// when
+//     $m : PollutantMeasurment(no2 <= 40)
+// then
+//     $m.setNo2Status(AirQualityCategory.DOBAR);
+// end
+
+// rule "NO2 UMEREN"
+// when
+//     $m : PollutantMeasurment(no2 > 40 && no2 <= 90)
+// then
+//     $m.setNo2Status(AirQualityCategory.UMEREN);
+// end
+
+// rule "NO2 LOS"
+// when
+//     $m : PollutantMeasurment(no2 > 90 && no2 <= 180)
+// then
+//     $m.setNo2Status(AirQualityCategory.LOS);
+// end
+
+// rule "NO2 OPASAN"
+// when
+//     $m : PollutantMeasurment(no2 > 180)
+// then
+//     $m.setNo2Status(AirQualityCategory.OPASAN);
+// end
+
+// // rule "Kombinovanje i preporuka"
+// // when
+// //     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
+// //     $user : UserProfile($type : userType)
+// //     $status : AirQualityStatus()
+// // then
+// //     AirQualityCategory finalCategory = AirQualityCategory.DOBAR;
+
+// //     // Najgora kategorija među PM2.5, PM10 i NO2
+// //     if($pm25Status == AirQualityCategory.OPASAN || $pm10Status == AirQualityCategory.OPASAN || $no2Status == AirQualityCategory.OPASAN)
+// //         finalCategory = AirQualityCategory.OPASAN;
+// //     else if($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS || $no2Status == AirQualityCategory.LOS)
+// //         finalCategory = AirQualityCategory.LOS;
+// //     else if($pm25Status == AirQualityCategory.UMEREN || $pm10Status == AirQualityCategory.UMEREN || $no2Status == AirQualityCategory.UMEREN)
+// //         finalCategory = AirQualityCategory.UMEREN;
+
+// //     $status.setCategory(finalCategory);
+// //     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
+
+// //     // Preporuka po tipu korisnika
+// //     if(finalCategory == AirQualityCategory.LOS && $type == UserCategory.DETE) {
+// //         $status.setRecommendation("Ostati unutra");
+// //     } else if(finalCategory == AirQualityCategory.OPASAN) {
+// //         $status.setRecommendation("Izbegavati napolje, koristiti masku");
+// //     } else {
+// //         $status.setRecommendation("Bez posebnih mera");
+// //     }
+// // end
+
+// ///////////////////////////////////////
+// /// Kombinovanje i preporuka
+// //////////////////////////////////////
+
+// rule "Finalna Kategorija DOBAR"
 // when
 //     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
+//     eval($pm25Status == AirQualityCategory.DOBAR && $pm10Status == AirQualityCategory.DOBAR && $no2Status == AirQualityCategory.DOBAR)
 //     $user : UserProfile($type : userType)
 //     $status : AirQualityStatus()
 // then
-//     AirQualityCategory finalCategory = AirQualityCategory.DOBAR;
-
-//     // Najgora kategorija među PM2.5, PM10 i NO2
-//     if($pm25Status == AirQualityCategory.OPASAN || $pm10Status == AirQualityCategory.OPASAN || $no2Status == AirQualityCategory.OPASAN)
-//         finalCategory = AirQualityCategory.OPASAN;
-//     else if($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS || $no2Status == AirQualityCategory.LOS)
-//         finalCategory = AirQualityCategory.LOS;
-//     else if($pm25Status == AirQualityCategory.UMEREN || $pm10Status == AirQualityCategory.UMEREN || $no2Status == AirQualityCategory.UMEREN)
-//         finalCategory = AirQualityCategory.UMEREN;
-
-//     $status.setCategory(finalCategory);
+//     $status.setCategory(AirQualityCategory.DOBAR);
 //     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
-
-//     // Preporuka po tipu korisnika
-//     if(finalCategory == AirQualityCategory.LOS && $type == UserCategory.DETE) {
-//         $status.setRecommendation("Ostati unutra");
-//     } else if(finalCategory == AirQualityCategory.OPASAN) {
-//         $status.setRecommendation("Izbegavati napolje, koristiti masku");
-//     } else {
-//         $status.setRecommendation("Bez posebnih mera");
-//     }
+//     $status.setRecommendation("Bez posebnih mera");
 // end
 
-///////////////////////////////////////
-/// Kombinovanje i preporuka
-//////////////////////////////////////
-
-rule "Finalna Kategorija DOBAR"
-when
-    $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
-    eval($pm25Status == AirQualityCategory.DOBAR && $pm10Status == AirQualityCategory.DOBAR && $no2Status == AirQualityCategory.DOBAR)
-    $user : UserProfile($type : userType)
-    $status : AirQualityStatus()
-then
-    $status.setCategory(AirQualityCategory.DOBAR);
-    $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
-    $status.setRecommendation("Bez posebnih mera");
-end
-
-rule "Finalna Kategorija UMEREN"
-when
-    $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
-    eval($pm25Status == AirQualityCategory.UMEREN || $pm10Status == AirQualityCategory.UMEREN || $no2Status == AirQualityCategory.UMEREN)
-    $user : UserProfile($type : userType)
-    $status : AirQualityStatus()
-then
-    $status.setCategory(AirQualityCategory.UMEREN);
-    $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
-    $status.setRecommendation("Bez posebnih mera");
-end
-
-rule "Finalna Kategorija LOS"
-when
-    $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
-    eval($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS || $no2Status == AirQualityCategory.LOS)
-    $user : UserProfile($type : userType == UserCategory.DETE)
-    $status : AirQualityStatus()
-then
-    $status.setCategory(AirQualityCategory.LOS);
-    $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
-    $status.setRecommendation("Ostati unutra");
-end
-
-rule "Finalna Kategorija LOS odrasli"
-when
-    $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
-    eval($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS || $no2Status == AirQualityCategory.LOS)
-    $user : UserProfile($type : userType != UserCategory.DETE)
-    $status : AirQualityStatus()
-then
-    $status.setCategory(AirQualityCategory.LOS);
-    $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
-    $status.setRecommendation("Bez posebnih mera");
-end
-
-rule "Finalna Kategorija OPASAN"
-when
-    $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
-    eval($pm25Status == AirQualityCategory.OPASAN || $pm10Status == AirQualityCategory.OPASAN || $no2Status == AirQualityCategory.OPASAN)
-    $user : UserProfile($type : userType)
-    $status : AirQualityStatus()
-then
-    $status.setCategory(AirQualityCategory.OPASAN);
-    $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
-    $status.setRecommendation("Izbegavati napolje, koristiti masku");
-end
-
-// rule "Kombinovanje i preporuka"
+// rule "Finalna Kategorija UMEREN"
 // when
-//     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status)
+//     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
+//     eval($pm25Status == AirQualityCategory.UMEREN || $pm10Status == AirQualityCategory.UMEREN || $no2Status == AirQualityCategory.UMEREN)
 //     $user : UserProfile($type : userType)
 //     $status : AirQualityStatus()
 // then
-//     // String finalCategory = "DOBAR";
-//     AirQualityCategory finalCategory = AirQualityCategory.DOBAR;
-//     // Najgora kategorija
-//     if($pm25Status == AirQualityCategory.OPASAN || $pm10Status == AirQualityCategory.OPASAN) finalCategory = AirQualityCategory.OPASAN;
-//     else if($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS) finalCategory = AirQualityCategory.LOS;
-//     else if($pm25Status == AirQualityCategory.UMEREN || $pm10Status == AirQualityCategory.UMEREN) finalCategory = AirQualityCategory.UMEREN;
-
-//     $status.setCategory(finalCategory);
-//     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status);
-
-//     // Preporuka po tipu korisnika
-//     if(finalCategory == AirQualityCategory.LOS && $type == UserCategory.DETE) {
-//         $status.setRecommendation("Ostati unutra");
-//     } else if(finalCategory == AirQualityCategory.OPASAN) {
-//         $status.setRecommendation("Izbegavati napolje, koristiti masku");
-//     } else {
-//         $status.setRecommendation("Bez posebnih mera");
-//     }
+//     $status.setCategory(AirQualityCategory.UMEREN);
+//     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
+//     $status.setRecommendation("Bez posebnih mera");
 // end
+
+// rule "Finalna Kategorija LOS"
+// when
+//     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
+//     eval($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS || $no2Status == AirQualityCategory.LOS)
+//     $user : UserProfile($type : userType == UserCategory.DETE)
+//     $status : AirQualityStatus()
+// then
+//     $status.setCategory(AirQualityCategory.LOS);
+//     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
+//     $status.setRecommendation("Ostati unutra");
+// end
+
+// rule "Finalna Kategorija LOS odrasli"
+// when
+//     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
+//     eval($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS || $no2Status == AirQualityCategory.LOS)
+//     $user : UserProfile($type : userType != UserCategory.DETE)
+//     $status : AirQualityStatus()
+// then
+//     $status.setCategory(AirQualityCategory.LOS);
+//     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
+//     $status.setRecommendation("Bez posebnih mera");
+// end
+
+// rule "Finalna Kategorija OPASAN"
+// when
+//     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status, $no2Status : no2Status)
+//     eval($pm25Status == AirQualityCategory.OPASAN || $pm10Status == AirQualityCategory.OPASAN || $no2Status == AirQualityCategory.OPASAN)
+//     $user : UserProfile($type : userType)
+//     $status : AirQualityStatus()
+// then
+//     $status.setCategory(AirQualityCategory.OPASAN);
+//     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status + ", NO2=" + $no2Status);
+//     $status.setRecommendation("Izbegavati napolje, koristiti masku");
+// end
+
+// // rule "Kombinovanje i preporuka"
+// // when
+// //     $m : PollutantMeasurment($pm25Status : pm25Status, $pm10Status : pm10Status)
+// //     $user : UserProfile($type : userType)
+// //     $status : AirQualityStatus()
+// // then
+// //     // String finalCategory = "DOBAR";
+// //     AirQualityCategory finalCategory = AirQualityCategory.DOBAR;
+// //     // Najgora kategorija
+// //     if($pm25Status == AirQualityCategory.OPASAN || $pm10Status == AirQualityCategory.OPASAN) finalCategory = AirQualityCategory.OPASAN;
+// //     else if($pm25Status == AirQualityCategory.LOS || $pm10Status == AirQualityCategory.LOS) finalCategory = AirQualityCategory.LOS;
+// //     else if($pm25Status == AirQualityCategory.UMEREN || $pm10Status == AirQualityCategory.UMEREN) finalCategory = AirQualityCategory.UMEREN;
+
+// //     $status.setCategory(finalCategory);
+// //     $status.setExplanation("PM2.5=" + $pm25Status + ", PM10=" + $pm10Status);
+
+// //     // Preporuka po tipu korisnika
+// //     if(finalCategory == AirQualityCategory.LOS && $type == UserCategory.DETE) {
+// //         $status.setRecommendation("Ostati unutra");
+// //     } else if(finalCategory == AirQualityCategory.OPASAN) {
+// //         $status.setRecommendation("Izbegavati napolje, koristiti masku");
+// //     } else {
+// //         $status.setRecommendation("Bez posebnih mera");
+// //     }
+// // end

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/backward/air-backwrad-rules.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/backward/air-backwrad-rules.drl
@@ -1,157 +1,157 @@
-package rules.backward
+// package rules.backward
 
-import java.util.Arrays;
-import java.util.List;
+// import java.util.Arrays;
+// import java.util.List;
 
-import com.ftn.model.AirPollutionEvent;
-import com.ftn.model.AirQualityStatus;
-import com.ftn.model.AirQualityCategory;
-import com.ftn.model.UserProfile;
-import com.ftn.model.UserCategory;
+// import com.ftn.model.AirPollutionEvent;
+// import com.ftn.model.AirQualityStatus;
+// import com.ftn.model.AirQualityCategory;
+// import com.ftn.model.UserProfile;
+// import com.ftn.model.UserCategory;
 
-// =====================================================================
-declare HypothesisDependency
-    conclusion     : String
-    prerequisites  : java.util.List
-end
+// // =====================================================================
+// declare HypothesisDependency
+//     conclusion     : String
+//     prerequisites  : java.util.List
+// end
 
-// =====================================================================
-// Inicijalizacija stabla zavisnosti za "Opasan vazduh" i preporuke
-// Root hipoteza: "IssueAlertOpasan" (izdati upozorenje: OPASAN)
-// Slojevi niže: kombinacije polutanata + vremenskih uslova + profila
-// =====================================================================
-rule "Init dependencies for Air Quality backward"
-salience 100
-when
-    not( HypothesisDependency() )
-then
-    System.out.println(">> Init backward dependencies for Air Quality...");
+// // =====================================================================
+// // Inicijalizacija stabla zavisnosti za "Opasan vazduh" i preporuke
+// // Root hipoteza: "IssueAlertOpasan" (izdati upozorenje: OPASAN)
+// // Slojevi niže: kombinacije polutanata + vremenskih uslova + profila
+// // =====================================================================
+// rule "Init dependencies for Air Quality backward"
+// salience 100
+// when
+//     not( HypothesisDependency() )
+// then
+//     System.out.println(">> Init backward dependencies for Air Quality...");
 
-    // --- ROOT: izdati upozorenje (opasan) ---
-    // tražimo: (SeverePollution OR MultiPollutantHigh) AND (UnfavorableWeather) 
-    // i po mogućnosti SensitiveUser za jače preporuke
-    insert( new HypothesisDependency(
-        "IssueAlertOpasan",
-        Arrays.asList("OverallStatusOpasan", "UnfavorableWeather")
-    ) );
+//     // --- ROOT: izdati upozorenje (opasan) ---
+//     // tražimo: (SeverePollution OR MultiPollutantHigh) AND (UnfavorableWeather) 
+//     // i po mogućnosti SensitiveUser za jače preporuke
+//     insert( new HypothesisDependency(
+//         "IssueAlertOpasan",
+//         Arrays.asList("OverallStatusOpasan", "UnfavorableWeather")
+//     ) );
 
-    // Za personalizovanu eskalaciju: root+SensitiveUser => "StrongProtectAdvice"
-    insert( new HypothesisDependency(
-        "StrongProtectAdvice",
-        Arrays.asList("IssueAlertOpasan", "SensitiveUser")
-    ) );
+//     // Za personalizovanu eskalaciju: root+SensitiveUser => "StrongProtectAdvice"
+//     insert( new HypothesisDependency(
+//         "StrongProtectAdvice",
+//         Arrays.asList("IssueAlertOpasan", "SensitiveUser")
+//     ) );
 
-    // --- “Opasan” status izvođen iz polutanata ---
-    insert( new HypothesisDependency(
-        "OverallStatusOpasan",
-        Arrays.asList("SeverePollution") // ili "MultiPollutantHigh"
-    ) );
+//     // --- “Opasan” status izvođen iz polutanata ---
+//     insert( new HypothesisDependency(
+//         "OverallStatusOpasan",
+//         Arrays.asList("SeverePollution") // ili "MultiPollutantHigh"
+//     ) );
 
-    // Jedan jako visok polutant dovoljan
-    insert( new HypothesisDependency(
-        "SeverePollution",
-        Arrays.asList("PM25_Opasan_OR_PM10_Opasan_OR_NO2_Opasan_OR_O3_Opasan")
-    ) );
+//     // Jedan jako visok polutant dovoljan
+//     insert( new HypothesisDependency(
+//         "SeverePollution",
+//         Arrays.asList("PM25_Opasan_OR_PM10_Opasan_OR_NO2_Opasan_OR_O3_Opasan")
+//     ) );
 
-    // Vremenski uslovi koji pogoršavaju disperziju
-    insert( new HypothesisDependency(
-        "UnfavorableWeather",
-        Arrays.asList("LowWind_OR_NoPrecip")
-    ) );
+//     // Vremenski uslovi koji pogoršavaju disperziju
+//     insert( new HypothesisDependency(
+//         "UnfavorableWeather",
+//         Arrays.asList("LowWind_OR_NoPrecip")
+//     ) );
 
-    // --- Sensitive user (profil) ---
-    insert( new HypothesisDependency(
-        "SensitiveUser",
-        Arrays.asList("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant")
-    ) );
-end
+//     // --- Sensitive user (profil) ---
+//     insert( new HypothesisDependency(
+//         "SensitiveUser",
+//         Arrays.asList("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant")
+//     ) );
+// end
 
-// =====================================================================
-// REKURZIVNA PROVERA: bazni dokazi su direktno iz činjenica (fakta)
-// ili se hipoteza dokazuje tako što su sve njene pretpostavke dokazane.
-// =====================================================================
-query proveHypothesis(String $h)
-    // -------------------- Bazni (atomarni) uslovi --------------------
-    // POLUTANTI – pragovi iz specifikacije (PM2.5 / PM10 ± ekvivalenti)
-    (
-        // PM2.5
-        ( eval($h.equals("PM25_Opasan")) and exists AirPollutionEvent( pm25 > 55 ) ) or
-        ( eval($h.equals("PM25_Los"))    and exists AirPollutionEvent( pm25 > 35, pm25 <= 55 ) ) or
-        ( eval($h.equals("PM25_Umeren")) and exists AirPollutionEvent( pm25 > 15, pm25 <= 35 ) ) or
-        ( eval($h.equals("PM25_Dobar"))  and exists AirPollutionEvent( pm25 <= 15 ) ) or
+// // =====================================================================
+// // REKURZIVNA PROVERA: bazni dokazi su direktno iz činjenica (fakta)
+// // ili se hipoteza dokazuje tako što su sve njene pretpostavke dokazane.
+// // =====================================================================
+// query proveHypothesis(String $h)
+//     // -------------------- Bazni (atomarni) uslovi --------------------
+//     // POLUTANTI – pragovi iz specifikacije (PM2.5 / PM10 ± ekvivalenti)
+//     (
+//         // PM2.5
+//         ( eval($h.equals("PM25_Opasan")) and exists AirPollutionEvent( pm25 > 55 ) ) or
+//         ( eval($h.equals("PM25_Los"))    and exists AirPollutionEvent( pm25 > 35, pm25 <= 55 ) ) or
+//         ( eval($h.equals("PM25_Umeren")) and exists AirPollutionEvent( pm25 > 15, pm25 <= 35 ) ) or
+//         ( eval($h.equals("PM25_Dobar"))  and exists AirPollutionEvent( pm25 <= 15 ) ) or
 
-        // PM10
-        ( eval($h.equals("PM10_Opasan")) and exists AirPollutionEvent( pm10 > 100 ) ) or
-        ( eval($h.equals("PM10_Los"))    and exists AirPollutionEvent( pm10 > 50,  pm10 <= 100 ) ) or
-        ( eval($h.equals("PM10_Umeren")) and exists AirPollutionEvent( pm10 > 25,  pm10 <= 50 ) ) or
-        ( eval($h.equals("PM10_Dobar"))  and exists AirPollutionEvent( pm10 <= 25 ) ) or
+//         // PM10
+//         ( eval($h.equals("PM10_Opasan")) and exists AirPollutionEvent( pm10 > 100 ) ) or
+//         ( eval($h.equals("PM10_Los"))    and exists AirPollutionEvent( pm10 > 50,  pm10 <= 100 ) ) or
+//         ( eval($h.equals("PM10_Umeren")) and exists AirPollutionEvent( pm10 > 25,  pm10 <= 50 ) ) or
+//         ( eval($h.equals("PM10_Dobar"))  and exists AirPollutionEvent( pm10 <= 25 ) ) or
 
-        // NO2 (primer granica – prilagodi tvojim forward pravilima ako već postoje)
-        ( eval($h.equals("NO2_Opasan"))  and exists AirPollutionEvent( no2 > 200 ) ) or
-        ( eval($h.equals("O3_Opasan"))   and exists AirPollutionEvent( o3  > 180 ) ) or
+//         // NO2 (primer granica – prilagodi tvojim forward pravilima ako već postoje)
+//         ( eval($h.equals("NO2_Opasan"))  and exists AirPollutionEvent( no2 > 200 ) ) or
+//         ( eval($h.equals("O3_Opasan"))   and exists AirPollutionEvent( o3  > 180 ) ) or
 
-        // Agregati baznih polutanata kao “OR” čvorovi
-        ( eval($h.equals("PM25_Opasan_OR_PM10_Opasan_OR_NO2_Opasan_OR_O3_Opasan"))
-              and ( exists AirPollutionEvent( pm25 > 55 ) 
-                 or exists AirPollutionEvent( pm10 > 100 )
-                 or exists AirPollutionEvent( no2  > 200 )
-                 or exists AirPollutionEvent( o3   > 180 ) ) ) or
+//         // Agregati baznih polutanata kao “OR” čvorovi
+//         ( eval($h.equals("PM25_Opasan_OR_PM10_Opasan_OR_NO2_Opasan_OR_O3_Opasan"))
+//               and ( exists AirPollutionEvent( pm25 > 55 ) 
+//                  or exists AirPollutionEvent( pm10 > 100 )
+//                  or exists AirPollutionEvent( no2  > 200 )
+//                  or exists AirPollutionEvent( o3   > 180 ) ) ) or
 
-        // Vreme
-        ( eval($h.equals("LowWind"))     and exists AirPollutionEvent( windSpeed < 1.5 ) ) or
-        ( eval($h.equals("NoPrecip"))    and exists AirPollutionEvent( precipitation == false ) ) or
-        ( eval($h.equals("LowWind_OR_NoPrecip"))
-              and ( exists AirPollutionEvent( windSpeed < 1.5 )
-                 or exists AirPollutionEvent( precipitation == false ) ) ) or
+//         // Vreme
+//         ( eval($h.equals("LowWind"))     and exists AirPollutionEvent( windSpeed < 1.5 ) ) or
+//         ( eval($h.equals("NoPrecip"))    and exists AirPollutionEvent( precipitation == false ) ) or
+//         ( eval($h.equals("LowWind_OR_NoPrecip"))
+//               and ( exists AirPollutionEvent( windSpeed < 1.5 )
+//                  or exists AirPollutionEvent( precipitation == false ) ) ) or
 
-        // Profil korisnika (oslanja se na tvoju klasu UserProfile/UserCategory)
-        ( eval($h.equals("IsChild"))     and exists UserProfile( userType == UserCategory.CHILD ) ) or
-        ( eval($h.equals("IsElderly"))   and exists UserProfile( userType == UserCategory.ELDERLY ) ) or
-        ( eval($h.equals("IsChronic"))   and exists UserProfile( userType == UserCategory.CHRONIC ) ) or
-        ( eval($h.equals("IsPregnant"))  and exists UserProfile( userType == UserCategory.PREGNANT ) ) or
-        ( eval($h.equals("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant"))
-              and exists UserProfile( userType in (UserCategory.CHILD, UserCategory.ELDERLY, UserCategory.CHRONIC, UserCategory.PREGNANT) ) )
-    )
-    or
-    // -------------------- Rekurzivni korak ---------------------------
-    (
-        $z : HypothesisDependency( conclusion == $h )
-        and not(
-            String($p: this) from $z.prerequisites
-            and
-            not proveHypothesis($p;)
-        )
-    )
-end
+//         // Profil korisnika (oslanja se na tvoju klasu UserProfile/UserCategory)
+//         ( eval($h.equals("IsChild"))     and exists UserProfile( userType == UserCategory.CHILD ) ) or
+//         ( eval($h.equals("IsElderly"))   and exists UserProfile( userType == UserCategory.ELDERLY ) ) or
+//         ( eval($h.equals("IsChronic"))   and exists UserProfile( userType == UserCategory.CHRONIC ) ) or
+//         ( eval($h.equals("IsPregnant"))  and exists UserProfile( userType == UserCategory.PREGNANT ) ) or
+//         ( eval($h.equals("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant"))
+//               and exists UserProfile( userType in (UserCategory.CHILD, UserCategory.ELDERLY, UserCategory.CHRONIC, UserCategory.PREGNANT) ) )
+//     )
+//     or
+//     // -------------------- Rekurzivni korak ---------------------------
+//     (
+//         $z : HypothesisDependency( conclusion == $h )
+//         and not(
+//             String($p: this) from $z.prerequisites
+//             and
+//             not proveHypothesis($p;)
+//         )
+//     )
+// end
 
-// =====================================================================
-// Završna pravila: kad se hipoteze dokažu, upiši status + objašnjenje
-// =====================================================================
+// // =====================================================================
+// // Završna pravila: kad se hipoteze dokažu, upiši status + objašnjenje
+// // =====================================================================
 
-// OPASAN – opšte upozorenje
-rule "Confirm OPASAN via backward reasoning"
-salience 10
-no-loop true
-when
-    proveHypothesis("IssueAlertOpasan";)
-    $status : AirQualityStatus()
-then
-    System.out.println(">> OPASAN (backward): visoki polutanti + nepovoljno vreme");
-    $status.setCategory(AirQualityCategory.OPASAN);
-    $status.setExplanation("Dokazano rekurzivno: (SeverePollution OR MultiPollutantHigh) i nepovoljno vreme.");
-    $status.setRecommendation("Ostanite u zatvorenom; koristite P2/P3 maske; izbegavajte napor napolju.");
-    update($status);
-end
+// // OPASAN – opšte upozorenje
+// rule "Confirm OPASAN via backward reasoning"
+// salience 10
+// no-loop true
+// when
+//     proveHypothesis("IssueAlertOpasan";)
+//     $status : AirQualityStatus()
+// then
+//     System.out.println(">> OPASAN (backward): visoki polutanti + nepovoljno vreme");
+//     $status.setCategory(AirQualityCategory.OPASAN);
+//     $status.setExplanation("Dokazano rekurzivno: (SeverePollution OR MultiPollutantHigh) i nepovoljno vreme.");
+//     $status.setRecommendation("Ostanite u zatvorenom; koristite P2/P3 maske; izbegavajte napor napolju.");
+//     update($status);
+// end
 
-// OPASAN + rizične grupe – jača poruka
-rule "Personalized strong advice for sensitive users"
-salience 9
-no-loop true
-when
-    proveHypothesis("StrongProtectAdvice";)
-    $status : AirQualityStatus( category == AirQualityCategory.OPASAN )
-then
-    System.out.println(">> OPASAN (sensitive): posebne preporuke");
-    $status.setRecommendation($status.getRecommendation() + " Posebno za rizične grupe: izbegavati izlazak; konsultovati lekara ako se jave simptomi.");
-    update($status);
-end
+// // OPASAN + rizične grupe – jača poruka
+// rule "Personalized strong advice for sensitive users"
+// salience 9
+// no-loop true
+// when
+//     proveHypothesis("StrongProtectAdvice";)
+//     $status : AirQualityStatus( category == AirQualityCategory.OPASAN )
+// then
+//     System.out.println(">> OPASAN (sensitive): posebne preporuke");
+//     $status.setRecommendation($status.getRecommendation() + " Posebno za rizične grupe: izbegavati izlazak; konsultovati lekara ako se jave simptomi.");
+//     update($status);
+// end

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/basicRules/basic-rules.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/basicRules/basic-rules.drl
@@ -1,0 +1,745 @@
+package rules.basicRules
+
+import com.ftn.model.Measurement;
+import com.ftn.model.Pollutant;
+import com.ftn.model.PollutantType;
+import com.ftn.model.AirQualityCategory;
+import com.ftn.model.DecisionExplanations;
+import com.ftn.model.AirQualityInfo;
+import com.ftn.model.User;
+import com.ftn.model.UserType;
+import com.ftn.model.messages.Message;
+import com.ftn.model.messages.GeneralMessage;
+import com.ftn.model.messages.SpecializedMessage;
+import com.ftn.model.messages.InstitutionalMessage;
+import com.ftn.model.AirQualityInput;
+import java.util.List;
+import java.util.ArrayList;
+import java.time.LocalDateTime;
+
+////////////////////////////
+// PM2.5 - KATEGORIZACIJA//
+//////////////////////////
+
+rule "PM2.5 GOOD"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM2_5, value <= 15) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.GOOD);
+end
+
+rule "PM2.5 MODERATE"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM2_5, value > 15 && value <= 35) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.MODERATE);
+end
+
+rule "PM2.5 POOR"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM2_5, value > 35 && value <= 55) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.POOR);
+end
+
+rule "PM2.5 HAZARDOUS"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM2_5, value > 55) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.HAZARDOUS);
+end
+
+////////////////////////////
+// PM10 - KATEGORIZACIJA//
+//////////////////////////
+
+rule "PM10 GOOD"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM10, value <= 25) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.GOOD);
+end
+
+rule "PM10 MODERATE"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM10, value > 25 && value <= 50) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.MODERATE);
+end
+
+rule "PM10 POOR"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM10, value > 50 && value <= 100) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.POOR);
+end
+
+rule "PM10 HAZARDOUS"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.PM10, value > 100) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.HAZARDOUS);
+end
+
+////////////////////////////
+// NO2 - KATEGORIZACIJA//
+//////////////////////////
+
+rule "NO2 GOOD"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.NO2, value <= 40) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.GOOD);
+end
+
+rule "NO2 MODERATE"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.NO2, value > 40 && value <= 90) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.MODERATE);
+end
+
+rule "NO2 POOR"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.NO2, value > 90 && value <= 180) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.POOR);
+end
+
+rule "NO2 HAZARDOUS"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.NO2, value > 180) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.HAZARDOUS);
+end
+
+////////////////////////////
+// O3 - KATEGORIZACIJA//
+//////////////////////////
+
+rule "O3 GOOD"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.O3, value <= 100) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.GOOD);
+end
+
+rule "O3 MODERATE"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.O3, value > 100 && value <= 140) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.MODERATE);
+end
+
+rule "O3 POOR"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.O3, value > 140 && value <= 180) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.POOR);
+end
+
+rule "O3 HAZARDOUS"
+when
+    $input : AirQualityInput( $measurement : pollutantMeasurment)
+    $p : Pollutant( pollutantType == PollutantType.O3, value > 180) from $measurement.pollutants
+then
+    $p.setStatus(AirQualityCategory.HAZARDOUS);
+end
+
+////////////////////////////
+// FINALNA KATEGORIZACIJA//
+//////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+rule "Set AirQualityInfo to HAZARDOUS for citizens"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.CITIZEN    
+    )
+    $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.HAZARDOUS);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+
+    info.setExplanation(explanation);
+
+    String messageContent = "WARNING! Air quality is hazardous to health. All citizens are advised to stay indoors and avoid any outdoor activities.";
+    LocalDateTime now = LocalDateTime.now();
+    GeneralMessage message = new GeneralMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+
+rule "Set AirQualityInfo to HAZARDOUS for risk groups"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.RISK_GROUP    
+    )
+    $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.HAZARDOUS);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+
+    info.setExplanation(explanation);
+
+    String messageContent = "WARNING! Air quality is hazardous to health. All citizens are advised to stay indoors and avoid any outdoor activities.";
+    String recommodendation = "Do not go outdoors under any circumstances. Keep children, elderly, and chronic patients indoors. Use protective measures indoors if possible (air filters, masks). Monitor health conditions closely; seek medical attention if necessary.";
+    LocalDateTime now = LocalDateTime.now();
+    SpecializedMessage message = new SpecializedMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+
+rule "Set AirQualityInfo to HAZARDOUS for institutions"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.INSTITUTION    
+    )
+    $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.HAZARDOUS);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+
+    info.setExplanation(explanation);
+
+    String messageContent = "WARNING! Air quality is hazardous to health. All citizens are advised to stay indoors and avoid any outdoor activities.";
+    String recommodendation = "Cancel all outdoor activities immediately. Keep doors and windows closed; ensure indoor air quality is safe. Protect all occupants, especially sensitive individuals. Follow emergency protocols if necessary (e.g., schools sending children home early, hospitals implementing safety measures). Provide official notices to staff, clients, and parents/guardians.";
+    LocalDateTime now = LocalDateTime.now();
+    InstitutionalMessage message = new InstitutionalMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+rule "Set AirQualityInfo to POOR (one pollutant) for citizens"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.CITIZEN 
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    $countPoor : Number(intValue == 1) from accumulate(
+        $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants,
+        count(1)
+    )
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.POOR);
+    
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+    
+    String messageContent = "Air quality is poor. It is recommended to limit time spent outdoors, especially during intense physical activities.";
+    LocalDateTime now = LocalDateTime.now();
+    GeneralMessage message = new GeneralMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    
+    info.setRecommendation(message);
+
+    insert(info);
+end
+
+rule "Set AirQualityInfo to POOR (one pollutant) for risk groups"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.RISK_GROUP 
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    $countPoor : Number(intValue == 1) from accumulate(
+        $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants,
+        count(1)
+    )
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.POOR);
+    
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+    
+    LocalDateTime now = LocalDateTime.now();
+    String messageContent = "Air quality is poor. It is recommended to limit time spent outdoors, especially during intense physical activities.";
+    String recommodendation = "Children, elderly, and chronic patients should minimize outdoor exposure. Avoid intense physical activities outside. Keep windows closed and use air purifiers if possible.";
+    SpecializedMessage message = new SpecializedMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+
+    info.setRecommendation(message);
+
+    insert(info);
+end
+
+rule "Set AirQualityInfo to POOR (one pollutant) for institutions"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.INSTITUTION
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    $countPoor : Number(intValue == 1) from accumulate(
+        $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants,
+        count(1)
+    )
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.POOR);
+    
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+    
+    LocalDateTime now = LocalDateTime.now();
+    String messageContent = "Air quality is poor. It is recommended to limit time spent outdoors, especially during intense physical activities.";
+    String recommodendation = "Limit outdoor activities for sensitive groups (e.g., children in schools, elderly in care homes). Ensure indoor areas have good air circulation or filtration. Consider rescheduling outdoor events or physical education classes.";
+    InstitutionalMessage message = new InstitutionalMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+
+    info.setRecommendation(message);
+
+    insert(info);
+end
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+rule "Set AirQualityInfo to VERY_POOR (multiple pollutants) for citizens"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.CITIZEN
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    $countPoor : Number(intValue > 1) from accumulate(
+        $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants,
+        count(1)
+    )
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.VERY_POOR);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is very poor. Avoid outdoor activities whenever possible. Children, the elderly, and people with chronic illnesses should be especially cautious.";
+    LocalDateTime now = LocalDateTime.now();
+    GeneralMessage message = new GeneralMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    
+    info.setRecommendation(message);
+
+    insert(info);
+end
+
+rule "Set AirQualityInfo to VERY_POOR (multiple pollutants) for risk groups"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.RISK_GROUP
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    $countPoor : Number(intValue > 1) from accumulate(
+        $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants,
+        count(1)
+    )
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.VERY_POOR);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is very poor. Avoid outdoor activities whenever possible. Children, the elderly, and people with chronic illnesses should be especially cautious.";
+    String recommodendation = "Risk groups should stay indoors as much as possible. Avoid outdoor exercise entirely. Ensure indoor air quality is good (air purifiers, closed windows). Have emergency medications ready (inhalers, etc.)"; 
+    LocalDateTime now = LocalDateTime.now();
+    SpecializedMessage message = new SpecializedMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+    
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+
+rule "Set AirQualityInfo to VERY_POOR (multiple pollutants) for institutions"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.INSTITUTION
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    $countPoor : Number(intValue > 1) from accumulate(
+        $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants,
+        count(1)
+    )
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.VERY_POOR);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is very poor. Avoid outdoor activities whenever possible. Children, the elderly, and people with chronic illnesses should be especially cautious.";
+    String recommodendation = "Suspend outdoor activities for all vulnerable groups. Keep windows closed, use air purifiers where possible. Postpone events that require physical effort outdoors. Inform staff and users about potential health risks."; 
+    LocalDateTime now = LocalDateTime.now();
+    InstitutionalMessage message = new InstitutionalMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+    
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+rule "Set AirQualityInfo to MODERATE for citizens"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.CITIZEN
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    not $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants
+
+    $p_moderate : Pollutant(status == AirQualityCategory.MODERATE) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.MODERATE);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is moderate. Most people will not be affected, but sensitive individuals may experience mild discomfort during prolonged outdoor activities.";
+    LocalDateTime now = LocalDateTime.now();
+    GeneralMessage message = new GeneralMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    
+    info.setRecommendation(message);
+
+    insert(info);
+end
+
+rule "Set AirQualityInfo to MODERATE for risk groups"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.RISK_GROUP
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    not $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants
+
+    $p_moderate : Pollutant(status == AirQualityCategory.MODERATE) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.MODERATE);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is moderate. Most people will not be affected, but sensitive individuals may experience mild discomfort during prolonged outdoor activities.";
+    String recommodendation = "Risk groups should limit prolonged outdoor activities if they feel discomfort. Consider taking regular breaks indoors. Keep medications handy if you have respiratory issues."; 
+    LocalDateTime now = LocalDateTime.now();
+    SpecializedMessage message = new SpecializedMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+    
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+
+rule "Set AirQualityInfo to MODERATE for institutions"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.INSTITUTION
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    not $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants
+
+    $p_moderate : Pollutant(status == AirQualityCategory.MODERATE) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.MODERATE);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is moderate. Most people will not be affected, but sensitive individuals may experience mild discomfort during prolonged outdoor activities.";
+    String recommodendation = "Suspend outdoor activities for all vulnerable groups. Keep windows closed, use air purifiers where possible. Postpone events that require physical effort outdoors. Inform staff and users about potential health risks."; 
+    LocalDateTime now = LocalDateTime.now();
+    InstitutionalMessage message = new InstitutionalMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+    
+    info.setRecommendation(message);
+
+    insert(info);
+end
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+rule "Set AirQualityInfo to GOOD for citizens"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.CITIZEN
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    not $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants
+    not $p_moderate : Pollutant(status == AirQualityCategory.MODERATE) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+
+    info.setAirCategory(AirQualityCategory.GOOD);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is good. There are no health risk, and you can safely enjoy outdoor activities.";
+    LocalDateTime now = LocalDateTime.now();
+    GeneralMessage message = new GeneralMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+
+rule "Set AirQualityInfo to GOOD for risk groups"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.RISK_GROUP
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    not $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants
+    not $p_moderate : Pollutant(status == AirQualityCategory.MODERATE) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.GOOD);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is good. There are no health risk, and you can safely enjoy outdoor activities.";
+    String recommodendation = "Children, elderly, and people with chronic illnesses can enjoy outdoor activities without special precautions."; 
+    LocalDateTime now = LocalDateTime.now();
+    SpecializedMessage message = new SpecializedMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+    
+    info.setRecommendation(message);
+
+    insert(info);
+end
+
+rule "Set AirQualityInfo to GOOD for institutions"
+when
+    $input : AirQualityInput( 
+        $measurement : pollutantMeasurment,
+        user != null,
+        user.userType == UserType.INSTITUTION
+    )
+    not $p_hazardous : Pollutant(status == AirQualityCategory.HAZARDOUS) from $measurement.pollutants
+    not $p_poor : Pollutant(status == AirQualityCategory.POOR) from $measurement.pollutants
+    not $p_moderate : Pollutant(status == AirQualityCategory.MODERATE) from $measurement.pollutants
+then
+    AirQualityInfo info = new AirQualityInfo();    
+    info.setInput($input);
+    
+    info.setAirCategory(AirQualityCategory.GOOD);
+
+    DecisionExplanations explanation = new DecisionExplanations();
+    List<String> allPollutants = new ArrayList<>();
+    for (Pollutant p : $measurement.getPollutants()) {
+        allPollutants.add(p.getPollutantType().name() + " = " + p.getValue());
+    }
+    explanation.setInfluencingPollutants(allPollutants);
+    
+    info.setExplanation(explanation);
+
+    String messageContent = "Air quality is good. There are no health risk, and you can safely enjoy outdoor activities.";
+    String recommodendation = "Institutions can operate normally. Outdoor activities for students or staff can continue as planned. No special precautions needed."; 
+    LocalDateTime now = LocalDateTime.now();
+    InstitutionalMessage message = new InstitutionalMessage();
+    message.setContent(messageContent);
+    message.setTimestamp(now);
+    message.setRecommendation(recommodendation);
+    
+    info.setRecommendation(message);
+    
+    insert(info);
+end
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/cepRules/cep-rules.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/cepRules/cep-rules.drl
@@ -1,79 +1,79 @@
-package rules.cepRules
+// package rules.cepRules
 
-import com.ftn.model.AirPollutionEvent;
-import com.ftn.model.AirQualityStatus;
-import com.ftn.model.AirQualityCategory;
+// import com.ftn.model.AirPollutionEvent;
+// import com.ftn.model.AirQualityStatus;
+// import com.ftn.model.AirQualityCategory;
 
-declare AirPollutionEvent
-    @role( event )
-    @timestamp( timestamp )
-end
+// declare AirPollutionEvent
+//     @role( event )
+//     @timestamp( timestamp )
+// end
 
-rule "PM2.5 raspon vece od 20 u 2m (DEMO)"
-dialect "java"
-no-loop true
-when
-  $max : Number() from accumulate(
-           $e : AirPollutionEvent() over window:time(2m),
-           max( $e.getPm25() )
-         )
-  $min : Number() from accumulate(
-           $e2 : AirPollutionEvent() over window:time(2m),
-           min( $e2.getPm25() )
-         )
-  eval( $max.doubleValue() - $min.doubleValue() > 20.0 )
-  $status : AirQualityStatus()
-then
-  System.out.println(">> Upozorenje: veliki porast PM2.5 (max-min > 20 u 2m)");
-  $status.setExplanation("Razlika PM2.5 u 2 minuta veća od 20 μg/m³ (demo).");
-  $status.setRecommendation("Pojačati monitoring i informisati javnost.");
-  update($status);
-end
+// rule "PM2.5 raspon vece od 20 u 2m (DEMO)"
+// dialect "java"
+// no-loop true
+// when
+//   $max : Number() from accumulate(
+//            $e : AirPollutionEvent() over window:time(2m),
+//            max( $e.getPm25() )
+//          )
+//   $min : Number() from accumulate(
+//            $e2 : AirPollutionEvent() over window:time(2m),
+//            min( $e2.getPm25() )
+//          )
+//   eval( $max.doubleValue() - $min.doubleValue() > 20.0 )
+//   $status : AirQualityStatus()
+// then
+//   System.out.println(">> Upozorenje: veliki porast PM2.5 (max-min > 20 u 2m)");
+//   $status.setExplanation("Razlika PM2.5 u 2 minuta veća od 20 μg/m³ (demo).");
+//   $status.setRecommendation("Pojačati monitoring i informisati javnost.");
+//   update($status);
+// end
 
 
 
-rule "Opasan vazduh - demo 2m, bez prekida"
-no-loop true
-when
+// rule "Opasan vazduh - demo 2m, bez prekida"
+// no-loop true
+// when
     
-    Number( intValue >= 4 ) from accumulate(
-        $d: AirPollutionEvent( $d.getPm25() >= 55 ) over window:time(2m),
-        count($d)
-    )
+//     Number( intValue >= 4 ) from accumulate(
+//         $d: AirPollutionEvent( $d.getPm25() >= 55 ) over window:time(2m),
+//         count($d)
+//     )
  
-    not( $d1: AirPollutionEvent( $d1.getPm25() < 55 ) over window:time(2m) )
+//     not( $d1: AirPollutionEvent( $d1.getPm25() < 55 ) over window:time(2m) )
 
-    $status : AirQualityStatus()
-then
-    System.out.println(">> Upozorenje institucijama (DEMO): vazduh je OPASAN neprekidno ≥2min!");
-    $status.setCategory(AirQualityCategory.OPASAN);
-    $status.setExplanation("PM2.5 ≥ 55 μg/m³ bez prekida u poslednja 2 minuta.");
-    $status.setRecommendation("Obavestiti institucije; izbegavati boravak na otvorenom.");
-    update($status);
-end
+//     $status : AirQualityStatus()
+// then
+//     System.out.println(">> Upozorenje institucijama (DEMO): vazduh je OPASAN neprekidno ≥2min!");
+//     $status.setCategory(AirQualityCategory.OPASAN);
+//     $status.setExplanation("PM2.5 ≥ 55 μg/m³ bez prekida u poslednja 2 minuta.");
+//     $status.setRecommendation("Obavestiti institucije; izbegavati boravak na otvorenom.");
+//     update($status);
+// end
 
 
-rule "Dugotrajno zadržavanje smoga (12h)"
-dialect "java"
-no-loop true
-when
+// rule "Dugotrajno zadržavanje smoga (12h)"
+// dialect "java"
+// no-loop true
+// when
 
-    $minPm25 : Number() from accumulate(
-        $e2 : AirPollutionEvent() over window:time(2m),
-        min($e2.getPm25())
-    )
-    eval( $minPm25.doubleValue() > 55.0 )
+//     $minPm25 : Number() from accumulate(
+//         $e2 : AirPollutionEvent() over window:time(2m),
+//         min($e2.getPm25())
+//     )
+//     eval( $minPm25.doubleValue() > 55.0 )
 
-    $avgWind : Number() from accumulate(
-        $e3 : AirPollutionEvent() over window:time(2m),
-        average($e3.getWindSpeed())
-    )
-    eval( $avgWind.doubleValue() < 2.0 )
+//     $avgWind : Number() from accumulate(
+//         $e3 : AirPollutionEvent() over window:time(2m),
+//         average($e3.getWindSpeed())
+//     )
+//     eval( $avgWind.doubleValue() < 2.0 )
 
-    $status : AirQualityStatus()
-then
-    System.out.println(">> Upozorenje: dugotrajno zadržavanje smoga (PM2.5 >55 12h, vetar slab)");
-    $status.setExplanation("PM2.5 je kontinuirano iznad 55 µg/m³ u 12h uz slab vetar.");
-    $status.setRecommendation("Očekivati zadržavanje smoga; savetovati ograničavanje boravka napolju.");
-    update($status);
-end
+//     $status : AirQualityStatus()
+// then
+//     System.out.println(">> Upozorenje: dugotrajno zadržavanje smoga (PM2.5 >55 12h, vetar slab)");
+//     $status.setExplanation("PM2.5 je kontinuirano iznad 55 µg/m³ u 12h uz slab vetar.");
+//     $status.setRecommendation("Očekivati zadržavanje smoga; savetovati ograničavanje boravka napolju.");
+//     update($status);
+// end

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/dto/AirQualityRequestDTO.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/dto/AirQualityRequestDTO.java
@@ -1,0 +1,12 @@
+package com.ftn.dto;
+
+import com.ftn.model.Measurement;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AirQualityRequestDTO {
+    private Measurement measurement;
+    private String email;
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityCategory.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityCategory.java
@@ -1,9 +1,17 @@
 package com.ftn.model;
 
+// public enum AirQualityCategory {
+//     DOBAR,
+//     UMEREN,
+//     LOS,
+//     VEOMA_LOS,
+//     OPASAN
+// }
+
 public enum AirQualityCategory {
-    DOBAR,
-    UMEREN,
-    LOS,
-    VEOMA_LOS,
-    OPASAN
+    GOOD,
+    MODERATE,
+    POOR,
+    VERY_POOR,
+    HAZARDOUS
 }

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityInfo.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityInfo.java
@@ -1,0 +1,41 @@
+package com.ftn.model;
+
+import javax.persistence.*;
+import lombok.*;
+
+import com.ftn.model.AirQualityCategory;
+import com.ftn.model.DecisionExplanations;
+import com.ftn.model.messages.Message;
+
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "air_quality_info")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AirQualityInfo{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private AirQualityCategory airCategory;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    private DecisionExplanations explanation;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    private Message recommendation;
+
+    @ElementCollection
+    @CollectionTable(name = "air_quality_warnings", joinColumns = @JoinColumn(name = "air_quality_info_id"))
+    @Column(name = "warning")
+    private List<String> warnings;
+
+    @OneToOne
+    @JoinColumn(name = "input_id") 
+    private AirQualityInput input;
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityInput.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityInput.java
@@ -1,22 +1,41 @@
 package com.ftn.model;
 
+import javax.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
-import com.ftn.model.PollutantMeasurment;
+import com.ftn.model.Measurement;
 import com.ftn.model.ContextData;
 import com.ftn.model.User;
 
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "air_quality_inputs")
+@Data
 public class AirQualityInput {
-    private PollutantMeasurment pollutantMeasurment;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    private Measurement pollutantMeasurment;
+
+    @OneToOne(cascade = CascadeType.ALL)
     private WeatherConditions weatherConditions;
+
+    @OneToOne(cascade = CascadeType.ALL)
     private ContextData contextData;
+
+    @ManyToOne
     private User user;
+    
     private LocalDateTime timestamp;
 
-    public AirQualityInput(PollutantMeasurment pollutantMeasurment,
-                           WeatherConditions weatherConditions,
-                           ContextData contextData,
-                           User user,
-                           LocalDateTime timestamp) {
+    public AirQualityInput() {}
+
+    public AirQualityInput(Measurement pollutantMeasurment, WeatherConditions weatherConditions, ContextData contextData, User user, LocalDateTime timestamp) {
         this.pollutantMeasurment = pollutantMeasurment;
         this.weatherConditions = weatherConditions;
         this.contextData = contextData;
@@ -24,8 +43,7 @@ public class AirQualityInput {
         this.timestamp = timestamp;
     }
 
-    // Getteri
-    public PollutantMeasurment getPollutantMeasurment() {
+    public Measurement getPollutantMeasurment() {
         return pollutantMeasurment;
     }
 
@@ -45,8 +63,7 @@ public class AirQualityInput {
         return timestamp;
     }
 
-    // Setteri
-    public void setPollutantMeasurment(PollutantMeasurment pollutantMeasurment) {
+    public void setPollutantMeasurment(Measurement pollutantMeasurment) {
         this.pollutantMeasurment = pollutantMeasurment;
     }
 

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityStatus.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirQualityStatus.java
@@ -3,7 +3,7 @@ package com.ftn.model;
 import com.ftn.model.AirQualityCategory;
 
 public class AirQualityStatus {
-    private AirQualityCategory category; // DOBAR, UMEREN, LOŠ, OPASAN
+    private AirQualityCategory category;
     private String explanation;
     private String recommendation;
 

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/ContextData.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/ContextData.java
@@ -1,22 +1,39 @@
 package com.ftn.model;
 
+import javax.persistence.*;
+import lombok.*;
+
 import com.ftn.model.Season;
+import com.ftn.model.TimeOfDay;
 
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "context_data")
+@Data
 public class ContextData {
-    private int trafficDensity;       // npr. skala 0-10
-    private boolean industrialActivity;
-    private String timeOfDay;         // jutro, podne, veče
-    private Season season;            // ZIMA / LETO
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-    public ContextData(int trafficDensity, boolean industrialActivity,
-                       String timeOfDay, Season season) {
+    private int trafficDensity;
+    
+    private boolean industrialActivity;
+
+    @Enumerated(EnumType.STRING)
+    private TimeOfDay timeOfDay;
+
+    @Enumerated(EnumType.STRING)
+    private Season season;
+
+    public ContextData(int trafficDensity, boolean industrialActivity, TimeOfDay timeOfDay, Season season) {
         this.trafficDensity = trafficDensity;
         this.industrialActivity = industrialActivity;
         this.timeOfDay = timeOfDay;
         this.season = season;
     }
 
-    // Getteri
     public int getTrafficDensity() {
         return trafficDensity;
     }
@@ -25,7 +42,7 @@ public class ContextData {
         return industrialActivity;
     }
 
-    public String getTimeOfDay() {
+    public TimeOfDay getTimeOfDay() {
         return timeOfDay;
     }
 
@@ -33,7 +50,6 @@ public class ContextData {
         return season;
     }
 
-    // Setteri
     public void setTrafficDensity(int trafficDensity) {
         this.trafficDensity = trafficDensity;
     }
@@ -42,7 +58,7 @@ public class ContextData {
         this.industrialActivity = industrialActivity;
     }
 
-    public void setTimeOfDay(String timeOfDay) {
+    public void setTimeOfDay(TimeOfDay timeOfDay) {
         this.timeOfDay = timeOfDay;
     }
 

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/DecisionExplanations.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/DecisionExplanations.java
@@ -1,0 +1,32 @@
+package com.ftn.model;
+
+import javax.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "decision_explanations")
+@Data
+public class DecisionExplanations {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ElementCollection
+    @CollectionTable(name = "influencing_pollutants", joinColumns = @JoinColumn(name = "decision_explanation_id"))
+    @Column(name = "pollutant")
+    private List<String> influencingPollutants;
+
+    @ElementCollection
+    @CollectionTable(name = "weather_factors", joinColumns = @JoinColumn(name = "decision_explanation_id"))
+    @Column(name = "factor")
+    private List<String> weatherFactors;
+
+    @ElementCollection
+    @CollectionTable(name = "context_factors", joinColumns = @JoinColumn(name = "decision_explanation_id"))
+    @Column(name = "factor")
+    private List<String> contextFactors;
+    
+    private String reasoning;
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/Measurement.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/Measurement.java
@@ -1,0 +1,34 @@
+package com.ftn.model;
+
+import javax.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "measurements")
+// @Data
+// @NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Measurement{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, mappedBy = "measurement")
+    private List<Pollutant> pollutants;
+
+    // Default konstruktor
+    public Measurement() {}
+
+    // Getter
+    public List<Pollutant> getPollutants() {
+        return pollutants;
+    }
+
+    // Setter
+    public void setPollutants(List<Pollutant> pollutants) {
+        this.pollutants = pollutants;
+    }
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/Pollutant.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/Pollutant.java
@@ -1,0 +1,37 @@
+package com.ftn.model;
+
+import javax.persistence.*;
+import lombok.*;
+
+import com.ftn.model.PollutantType;
+import com.ftn.model.AirQualityCategory;
+
+@Entity
+@Table(name = "pollutants")
+@Data
+public class Pollutant{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Enumerated(EnumType.STRING)
+    private PollutantType pollutantType;
+    private double value;
+    
+    @Enumerated(EnumType.STRING)
+    private AirQualityCategory status;
+
+    @ManyToOne
+    @JoinColumn(name = "measurement_id")
+    private Measurement measurement;
+
+    public Pollutant(){}
+
+    public Pollutant(PollutantType pollutantType, double value, AirQualityCategory status, Measurement measurement) {
+        this.pollutantType = pollutantType;
+        this.value = value;
+        this.status = status;
+        this.measurement = measurement;
+    }
+
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/PollutantType.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/PollutantType.java
@@ -1,0 +1,8 @@
+package com.ftn.model;
+
+public enum PollutantType{
+    PM2_5,
+    PM10,
+    NO2,
+    O3
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/TimeOfDay.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/TimeOfDay.java
@@ -1,0 +1,7 @@
+package com.ftn.model;
+
+public enum TimeOfDay{
+    MORNIGN,
+    NOON,
+    EVENING
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/WeatherConditions.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/WeatherConditions.java
@@ -1,11 +1,22 @@
 package com.ftn.model;
 
+import javax.persistence.*;
+import lombok.*;
+
 import com.ftn.model.WindCategory;
 
+@Entity
+@Table(name = "weather_conditions")
+@Data
 public class WeatherConditions {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     private double temperature;   // °C
     private double humidity;      // %
     private double windSpeed;     // m/s
+    @Enumerated(EnumType.STRING)
     private WindCategory windCategory;
     private double precipitation; // mm
     private double pressure;      // hPa

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/GeneralMessage.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/GeneralMessage.java
@@ -1,8 +1,12 @@
 package com.ftn.model.messages;
 
+import javax.persistence.*;
+import lombok.*;
+
 import com.ftn.model.AirQualityCategory;
 
+@Entity
+@Data
 public class GeneralMessage extends Message {
-    private AirQualityCategory AirQualityCategory; 
-    // npr. LOW, MEDIUM, HIGH – veže se za stanje vazduha
+
 }

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/InstitutionalMessage.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/InstitutionalMessage.java
@@ -1,9 +1,17 @@
 package com.ftn.model.messages;
 
-import lombok.Data;
+import javax.persistence.*;
+import lombok.*;
 
+import com.ftn.model.InstitutionType;
+
+import java.util.List;
+import java.util.Map;
+
+@Entity
 @Data
 public class InstitutionalMessage extends Message {
-    private String institutionType; // Škola, vrtić, bolnica...
-    private String recommendation;  // npr. "Prekinuti aktivnosti na otvorenom"
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String recommendation;
 }

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/Message.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/Message.java
@@ -1,11 +1,19 @@
 package com.ftn.model.messages;
 
-import lombok.Data;
+import javax.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
 
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public abstract class Message {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String content;          // Tekst poruke
-    private LocalDateTime timestamp; // Kada je poslata
+    private String content;
+    private LocalDateTime timestamp;
 }

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/SpecializedMessage.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/SpecializedMessage.java
@@ -1,10 +1,18 @@
 package com.ftn.model.messages;
 
+import javax.persistence.*;
+import lombok.*;
+
 import com.ftn.model.RiskType;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
+@Entity
 @Data
 public class SpecializedMessage extends Message {
-    private RiskType targetGroup; 
-    // npr. DETE, STARIJA_OSOBA, HRONICNI_BOLESNIK, TRUDNICA
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String recommendation;
 }

--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityInfoController.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityInfoController.java
@@ -1,0 +1,67 @@
+package com.ftn.controller;
+
+import com.ftn.model.*;
+import com.ftn.service.AirQualityInfoRepository;
+import com.ftn.service.AirQualityInputRepository;
+import com.ftn.service.UserRepository;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.KieServices;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import com.ftn.model.AirQualityInput;
+import com.ftn.dto.AirQualityRequestDTO;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/air-quality")
+public class AirQualityInfoController {
+
+    @Autowired
+    private AirQualityInfoRepository repository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AirQualityInputRepository inputRepository;
+
+    @PostMapping("/evaluate")
+    public AirQualityInfo evaluate(@RequestBody AirQualityRequestDTO request) {
+        System.out.println("REQUEST >> " + request);
+        
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new RuntimeException("User not found with email: " + request.getEmail()));
+        
+        AirQualityInput input = new AirQualityInput();
+        input.setUser(user);
+        input.setPollutantMeasurment(request.getMeasurement());
+        input.setTimestamp(LocalDateTime.now());
+
+        inputRepository.save(input);
+
+        KieServices ks = KieServices.Factory.get();
+        KieSession kieSession = ks.getKieClasspathContainer().newKieSession("basic-ksession");
+
+        kieSession.insert(input);
+        kieSession.fireAllRules();
+
+        AirQualityInfo result = null;
+        for (Object o : kieSession.getObjects()) {
+            if (o instanceof AirQualityInfo) {
+                result = (AirQualityInfo) o;
+                break;
+            }
+        }
+
+        kieSession.dispose();
+
+        System.out.println("RESULT>> " + result);
+        if (result != null) {
+            System.out.println("RESULT>> " + result);
+            repository.save(result);
+        }
+
+        return result;
+    }
+}

--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityInfoRepository.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityInfoRepository.java
@@ -1,0 +1,9 @@
+package com.ftn.service;
+
+import com.ftn.model.AirQualityInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AirQualityInfoRepository extends JpaRepository<AirQualityInfo, Long> {
+}

--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityInputRepository.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityInputRepository.java
@@ -1,0 +1,9 @@
+package com.ftn.service;
+
+import com.ftn.model.AirQualityInput;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AirQualityInputRepository extends JpaRepository<AirQualityInput, Long> {
+}

--- a/air-quality-app/src/app/app.routes.ts
+++ b/air-quality-app/src/app/app.routes.ts
@@ -6,7 +6,7 @@ import { AppComponent } from './app.component';
 import { NgModule } from '@angular/core';
 
 export const routes: Routes = [
-    { path: '', component: AppComponent },
+    { path: '', component: RegisterComponent },
     { path: 'login', component: LoginComponent },
     { path: 'register', component: RegisterComponent },
     { path: 'dashboard', component: DashboardComponent }

--- a/air-quality-app/src/app/auth/login/login.component.ts
+++ b/air-quality-app/src/app/auth/login/login.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from '../../service/auth.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-login',
@@ -14,7 +15,11 @@ export class LoginComponent {
   loginForm: FormGroup;
   errorMessage = '';
 
-  constructor(private fb: FormBuilder, private authService: AuthService) {
+  constructor(
+    private fb: FormBuilder, 
+    private authService: AuthService,
+    private router: Router
+  ) {
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required]
@@ -37,6 +42,8 @@ export class LoginComponent {
         console.log('Uspešna prijava na sistem', res);
         alert('Prijava uspesna!');
         this.loginForm.reset();
+
+        this.router.navigate(['/dashboard']);
       },
       error: (err) => {
         console.error('Greška pri prijavi', err);

--- a/air-quality-app/src/app/service/auth.service.ts
+++ b/air-quality-app/src/app/service/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +15,29 @@ export class AuthService {
     return this.http.post(`${this.baseUrl}/register`, userData);
   }
 
-  login(loginData: any): Observable<any> {
-    return this.http.post(`${this.baseUrl}/login`, loginData);
+  // login(loginData: any): Observable<any> {
+  //   return this.http.post(`${this.baseUrl}/login`, loginData);
+  // }
+
+   login(loginData: any): Observable<any> {
+    return this.http.post<any>(`${this.baseUrl}/login`, loginData).pipe(
+      tap((userData: any) => {
+        // Čuvamo podatke (npr. token i email) u localStorage
+        localStorage.setItem('user', JSON.stringify(userData));
+      })
+    );
+  }
+
+  getUser(): any {
+    const user = localStorage.getItem('user');
+    return user ? JSON.parse(user) : null;
+  }
+
+  isLoggedIn(): boolean {
+    return !!localStorage.getItem('user');
+  }
+
+  logout(): void {
+    localStorage.removeItem('user');
   }
 }


### PR DESCRIPTION
…irQualityInput, fire Drools rules, and persist results

Implemented the Air Quality evaluation workflow by updating the controller to accept Measurement and user email as input, fetching the corresponding User, and constructing the AirQualityInput entity. Added preprocessing to classify pollutant values into AirQualityCategory before inserting into the Drools session, ensuring that rules for citizens, risk groups, and institutions fire correctly. Persisted both the input and resulting AirQualityInfo entities to the database, and adjusted logging to verify correct rule execution and object creation. This enables proper real-time evaluation and generation of recommendations based on air quality levels.