### PR TITLE
CEP rules

### DIFF
--- a/Kvalitet_vazduha/kjar/src/main/resources/META-INF/kmodule.xml
+++ b/Kvalitet_vazduha/kjar/src/main/resources/META-INF/kmodule.xml
@@ -13,4 +13,8 @@
     <kbase name="basicRules" packages="basicRules">
         <ksession name="basic-ksession"/>
     </kbase>
+
+    <kbase name="rulesNewCEP" packages="rules/cepRules" eventProcessingMode="stream">
+        <ksession name="k-session-new-cep" type="stateful" clockType="realtime"/>
+    </kbase>
 </kmodule>

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/META-INF/kmodule.xml
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/META-INF/kmodule.xml
@@ -7,6 +7,10 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <kbase name="rulesCEP" packages="rules/cepRules" eventProcessingMode="stream">
         <ksession name="k-session-cep" type="stateful" clockType="realtime"/>
     </kbase>
+
+    <kbase name="rulesNewCEP" packages="rules/cepRules" eventProcessingMode="stream">
+        <ksession name="k-session-new-cep" type="stateful" clockType="realtime"/>
+    </kbase>
     
     <kbase name="backward-kbase" packages="rules/backward">
         <ksession name="backward-ksession"/>

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/cepRules/cep-rules.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/cepRules/cep-rules.drl
@@ -1,15 +1,37 @@
-// package rules.cepRules
+package rules.cepRules
 
-// import com.ftn.model.AirPollutionEvent;
-// import com.ftn.model.AirQualityStatus;
-// import com.ftn.model.AirQualityCategory;
+import com.ftn.model.AirPollutionEvent;
+import com.ftn.model.AirQualityStatus;
+import com.ftn.model.AirQualityCategory;
+import com.ftn.model.messages.Warning;
 
-// declare AirPollutionEvent
-//     @role( event )
-//     @timestamp( timestamp )
-// end
+declare AirPollutionEvent
+    @role( event )
+    @timestamp( timestamp )
+end
 
-// rule "PM2.5 raspon vece od 20 u 2m (DEMO)"
+rule "PM2.5 raspon vece od 20 u 2m"
+dialect "java"
+no-loop true
+when
+  $max : Number() from accumulate(
+           $e : AirPollutionEvent() over window:time(2m),
+           max( $e.getPm25() )
+         )
+  $min : Number() from accumulate(
+           $e2 : AirPollutionEvent() over window:time(2m),
+           min( $e2.getPm25() )
+         )
+  eval( $max.doubleValue() - $min.doubleValue() > 20.0 )
+  $warning : Warning()
+then
+  System.out.println(">> Upozorenje: veliki porast PM2.5 (max-min > 20 u 2m)");
+  $warning.setContent("WARNING >> Sudden incrase in pollution!");
+  // $status.setRecommendation("Pojačati monitoring i informisati javnost.");
+  update($warning);
+end
+
+// rule "PM2.5 raspon vece od 20 u 2m"
 // dialect "java"
 // no-loop true
 // when
@@ -22,58 +44,87 @@
 //            min( $e2.getPm25() )
 //          )
 //   eval( $max.doubleValue() - $min.doubleValue() > 20.0 )
-//   $status : AirQualityStatus()
+//   $warning : Warning(active == false)
 // then
 //   System.out.println(">> Upozorenje: veliki porast PM2.5 (max-min > 20 u 2m)");
-//   $status.setExplanation("Razlika PM2.5 u 2 minuta veća od 20 μg/m³ (demo).");
-//   $status.setRecommendation("Pojačati monitoring i informisati javnost.");
-//   update($status);
+//   $warning.setContent("WARNING >> Sudden incrase in pollution!");
+//   $warning.setActive(true);
+//   // $status.setRecommendation("Pojačati monitoring i informisati javnost.");
+//   update($warning);
 // end
 
-
-
-// rule "Opasan vazduh - demo 2m, bez prekida"
-// no-loop true
-// when
-    
-//     Number( intValue >= 4 ) from accumulate(
-//         $d: AirPollutionEvent( $d.getPm25() >= 55 ) over window:time(2m),
-//         count($d)
-//     )
- 
-//     not( $d1: AirPollutionEvent( $d1.getPm25() < 55 ) over window:time(2m) )
-
-//     $status : AirQualityStatus()
-// then
-//     System.out.println(">> Upozorenje institucijama (DEMO): vazduh je OPASAN neprekidno ≥2min!");
-//     $status.setCategory(AirQualityCategory.OPASAN);
-//     $status.setExplanation("PM2.5 ≥ 55 μg/m³ bez prekida u poslednja 2 minuta.");
-//     $status.setRecommendation("Obavestiti institucije; izbegavati boravak na otvorenom.");
-//     update($status);
-// end
-
-
-// rule "Dugotrajno zadržavanje smoga (12h)"
+// rule "PM2.5 stabilizacija (<10 u 2m)"
 // dialect "java"
 // no-loop true
 // when
-
-//     $minPm25 : Number() from accumulate(
-//         $e2 : AirPollutionEvent() over window:time(2m),
-//         min($e2.getPm25())
-//     )
-//     eval( $minPm25.doubleValue() > 55.0 )
-
-//     $avgWind : Number() from accumulate(
-//         $e3 : AirPollutionEvent() over window:time(2m),
-//         average($e3.getWindSpeed())
-//     )
-//     eval( $avgWind.doubleValue() < 2.0 )
-
-//     $status : AirQualityStatus()
+//   $max : Number() from accumulate(
+//            $e : AirPollutionEvent() over window:time(2m),
+//            max( $e.getPm25() )
+//          )
+//   $min : Number() from accumulate(
+//            $e2 : AirPollutionEvent() over window:time(2m),
+//            min( $e2.getPm25() )
+//          )
+//   eval( $max.doubleValue() - $min.doubleValue() < 10.0 )
+//   $warning : Warning(active == true)
 // then
-//     System.out.println(">> Upozorenje: dugotrajno zadržavanje smoga (PM2.5 >55 12h, vetar slab)");
-//     $status.setExplanation("PM2.5 je kontinuirano iznad 55 µg/m³ u 12h uz slab vetar.");
-//     $status.setRecommendation("Očekivati zadržavanje smoga; savetovati ograničavanje boravka napolju.");
-//     update($status);
+//   System.out.println("PM2.5 se stabilizovao (razlika < 10) — resetujem upozorenje");
+//   $warning.setActive(false);
+//   $warning.setContent("PM2.5 levels have stabilized");
+//   update($warning);
 // end
+
+rule "Opasan vazduh - demo 2m, bez prekida"
+no-loop true
+when
+    
+    Number( intValue >= 4 ) from accumulate(
+        $d: AirPollutionEvent( 
+                               $d.getPm25() >= 55 ||
+                               $d.getPm10() >= 100 ||
+                               $d.getNo2() >= 180 ||
+                               $d.getO3() >= 180 
+        ) over window:time(30s),
+        count($d)
+    )
+ 
+    // not( $d1: AirPollutionEvent( $d1.getPm25() < 55 ) over window:time(30s) )
+    // not( $d1: AirPollutionEvent( $d1.getPm10() < 100 ) over window:time(30s) )
+    // not( $d1: AirPollutionEvent( $d1.getNo2() < 180 ) over window:time(30s) )
+    // not( $d1: AirPollutionEvent( $d1.getO3() < 180 ) over window:time(30s) )
+
+    $warning : Warning()
+then
+    System.out.println(">> Upozorenje institucijama (DEMO): vazduh je OPASAN neprekidno ≥2min!");
+    $warning.setContent("Air quality has been hazardous for the last 6 hours. Limit outdoor activities.");
+    // $status.setCategory(AirQualityCategory.HAZARDOUS);
+    // $status.setExplanation("PM2.5 ≥ 55 μg/m³ bez prekida u poslednja 2 minuta.");
+    // $status.setRecommendation("Obavestiti institucije; izbegavati boravak na otvorenom.");
+    update($warning);
+end
+
+rule "Dugotrajno zadržavanje smoga (12h)"
+dialect "java"
+no-loop true
+when
+
+    $minPm25 : Number() from accumulate(
+        $e2 : AirPollutionEvent() over window:time(30s),
+        min($e2.getPm25())
+    )
+    eval( $minPm25.doubleValue() > 55.0 )
+
+    $avgWind : Number() from accumulate(
+        $e3 : AirPollutionEvent() over window:time(30s),
+        average($e3.getWindSpeed())
+    )
+    eval( $avgWind.doubleValue() < 2.0 )
+
+    $warning : Warning()
+then
+    System.out.println(">> Upozorenje: dugotrajno zadržavanje smoga (PM2.5 >55 12h, vetar slab)");
+    $warning.setContent("WARNING >> Prolonged smog detected!");
+    // $status.setExplanation("PM2.5 je kontinuirano iznad 55 µg/m³ u 12h uz slab vetar.");
+    // $status.setRecommendation("Očekivati zadržavanje smoga; savetovati ograničavanje boravka napolju.");
+    update($warning);
+end

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/cepRules/new-cep-rules.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/cepRules/new-cep-rules.drl
@@ -1,0 +1,132 @@
+// package rules.cepRules
+
+// import com.ftn.model.*;
+// import com.ftn.model.messages.*;
+// import java.time.LocalDateTime;
+
+// // declare AirQualityInput
+// //     @role(event)
+// //     @timestamp(timestamp)
+// // end
+
+// declare Pollutant
+//     @role(event)
+//     // @timestamp(timestamp)
+// end
+
+// rule "PM2.5 raspon vece od 20 u 2min (DEMO)"
+// dialect "java"
+// no-loop true
+// when
+//     $max : Number() from accumulate(
+//         $p : Pollutant( pollutantType == PollutantType.PM2_5 ) over window:time(2m),
+//         max($p.value)
+//     )
+
+//     $min : Number() from accumulate(
+//         $p : Pollutant( pollutantType == PollutantType.PM2_5 ) over window:time(2m),
+//         min($p.value)
+//     )
+
+//     eval( $max.doubleValue() - $min.doubleValue() > 20.0 )
+// then
+//     Warning warning = new Warning();
+    
+//     String content = "WARNING >> Sudden incrase in pollution!";
+//     LocalDateTime now = LocalDateTime.now();
+
+//     warning.setContent(content);
+//     warning.setTimeStamp(now);
+
+//     insert(warning);
+// end
+
+package rules.cepRules
+
+import com.ftn.model.AirPollutionEvent;
+import com.ftn.model.AirQualityStatus;
+import com.ftn.model.AirQualityCategory;
+
+import com.ftn.model.*;
+import com.ftn.model.messages.*;
+import java.time.LocalDateTime;
+
+declare AirPollutionEvent
+    @role( event )
+    @timestamp( timestamp )
+end
+
+rule "PM2.5 raspon vece od 20 u 2m (DEMO)"
+dialect "java"
+no-loop true
+when
+  $max : Number() from accumulate(
+           $e : AirPollutionEvent() over window:time(2m),
+           max( $e.getPm25() )
+         )
+  $min : Number() from accumulate(
+           $e2 : AirPollutionEvent() over window:time(2m),
+           min( $e2.getPm25() )
+         )
+  eval( $max.doubleValue() - $min.doubleValue() > 20.0 )
+  $warning : Warning()
+then
+    System.out.println(">> Upozorenje institucijama (DEMO): vazduh je OPASAN neprekidno ≥2min!");
+    // Warning warning = new Warning();
+    
+    // String content = "WARNING >> Sudden incrase in pollution!";
+    // LocalDateTime now = LocalDateTime.now();
+
+    // warning.setContent(content);
+    // warning.setTimestamp(now);
+    $warning.setContent("WARNING >> Sudden incrase in pollution!");
+    update($warning);
+end
+
+
+
+// rule "Opasan vazduh - demo 2m, bez prekida"
+// no-loop true
+// when
+    
+//     Number( intValue >= 4 ) from accumulate(
+//         $d: AirPollutionEvent( $d.getPm25() >= 55 ) over window:time(2m),
+//         count($d)
+//     )
+ 
+//     not( $d1: AirPollutionEvent( $d1.getPm25() < 55 ) over window:time(2m) )
+
+//     $status : AirQualityStatus()
+// then
+//     System.out.println(">> Upozorenje institucijama (DEMO): vazduh je OPASAN neprekidno ≥2min!");
+//     $status.setCategory(AirQualityCategory.OPASAN);
+//     $status.setExplanation("PM2.5 ≥ 55 μg/m³ bez prekida u poslednja 2 minuta.");
+//     $status.setRecommendation("Obavestiti institucije; izbegavati boravak na otvorenom.");
+//     update($status);
+// end
+
+
+// rule "Dugotrajno zadržavanje smoga (12h)"
+// dialect "java"
+// no-loop true
+// when
+
+//     $minPm25 : Number() from accumulate(
+//         $e2 : AirPollutionEvent() over window:time(2m),
+//         min($e2.getPm25())
+//     )
+//     eval( $minPm25.doubleValue() > 55.0 )
+
+//     $avgWind : Number() from accumulate(
+//         $e3 : AirPollutionEvent() over window:time(2m),
+//         average($e3.getWindSpeed())
+//     )
+//     eval( $avgWind.doubleValue() < 2.0 )
+
+//     $status : AirQualityStatus()
+// then
+//     System.out.println(">> Upozorenje: dugotrajno zadržavanje smoga (PM2.5 >55 12h, vetar slab)");
+//     $status.setExplanation("PM2.5 je kontinuirano iznad 55 µg/m³ u 12h uz slab vetar.");
+//     $status.setRecommendation("Očekivati zadržavanje smoga; savetovati ograničavanje boravka napolju.");
+//     update($status);
+// end

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirPollutionEvent.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/AirPollutionEvent.java
@@ -18,6 +18,8 @@ public class AirPollutionEvent {
 
     private long timestamp;  // vreme merenja
 
+    private String userEmail;
+
     // === Konstruktor bez argumenata (potreban za Drools) ===
     public AirPollutionEvent() {
     }
@@ -26,7 +28,7 @@ public class AirPollutionEvent {
     public AirPollutionEvent(double pm25, double pm10, double no2, double o3, double co2,
                              double windSpeed, boolean precipitation,
                              double temperature, double humidity, double pressure,
-                             long timestamp) {
+                             long timestamp, String userEmail) {
         this.pm25 = pm25;
         this.pm10 = pm10;
         this.no2 = no2;
@@ -38,14 +40,16 @@ public class AirPollutionEvent {
         this.humidity = humidity;
         this.pressure = pressure;
         this.timestamp = timestamp;
+        this.userEmail = userEmail;
     }
 
-     public AirPollutionEvent(double pm25, double pm10, double no2, double windSpeed, long timestamp) {
+     public AirPollutionEvent(double pm25, double pm10, double no2, double windSpeed, long timestamp, String userEmail) {
         this.pm10 = pm10;
         this.pm25 = pm25;
         this.no2 = no2;
         this.windSpeed = windSpeed;
         this.timestamp = timestamp;
+        this.userEmail = userEmail;
      }
 
     // === Getteri i setteri ===
@@ -136,6 +140,15 @@ public class AirPollutionEvent {
     public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
     }
+
+     public String getUserEmail() {
+        return userEmail;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+
 
     @Override
     public String toString() {

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/Warning.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/messages/Warning.java
@@ -1,0 +1,26 @@
+package com.ftn.model.messages;
+
+import javax.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+import com.ftn.model.User;
+
+@Entity
+@Data
+@Inheritance(strategy = InheritanceType.JOINED)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Warning {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, length = 500)
+    private String content;
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityEventController.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/AirQualityEventController.java
@@ -1,0 +1,143 @@
+package com.ftn.controller;
+
+import com.ftn.model.AirQualityInput;
+import com.ftn.model.messages.Warning;
+import com.ftn.model.*;
+import com.ftn.dto.AirQualityRequestDTO;
+import com.ftn.service.WarningRepository;
+import com.ftn.service.UserRepository;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.List;
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/air")
+@CrossOrigin(origins = "http://localhost:4200")
+public class AirQualityEventController {
+
+    private final KieContainer kieContainer;
+    private KieSession kSession;
+    private final WarningRepository warningRepository;
+    private final UserRepository userRepository;
+    private Warning warning;
+
+    public AirQualityEventController(KieContainer kieContainer, WarningRepository warningRepository, UserRepository userRepository) {
+        this.kieContainer = kieContainer;
+        this.warningRepository = warningRepository;
+        this.userRepository = userRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        this.kSession = kieContainer.newKieSession("k-session-new-cep");
+        System.out.println("CEP KieSession initialized for air quality monitoring.");
+        this.warning = new Warning();
+        this.kSession.insert(this.warning);
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (this.kSession != null) this.kSession.dispose();
+    }
+
+    // @PostMapping("/pm25Increase")
+    // public synchronized ResponseEntity<?> processAirQualityInput(@RequestBody AirQualityRequestDTO request) {
+    //     // System.out.println("Received new air quality input: " + input.getTimestamp());
+    //     System.out.println("REQUEST >> " + request);
+
+    //     User user = userRepository.findByEmail(request.getEmail())
+    //             .orElseThrow(() -> new RuntimeException("User not found with email: " + request.getEmail()));
+    //     // ubaci događaj u sesiju
+    //     // this.kSession.insert(input);
+
+    //     for(Pollutant p : request.getMeasurement().getPollutants()) {
+    //         this.kSession.insert(p);
+    //     }
+
+    //     // pokreni pravila
+    //     this.kSession.fireAllRules();
+
+    //     // prikupi sve Warning objekte koji su eventualno generisani
+    //     List<Warning> warnings = new ArrayList<>();
+    //     for (Object o : this.kSession.getObjects()) {
+    //         if (o instanceof Warning) {
+    //             Warning warning = (Warning) o;
+    //             warning.setUser(user);
+    //             warningRepository.save(warning);
+    //             warnings.add(warning);
+    //         }
+    //     }
+
+    //     if (warnings.isEmpty()) {
+    //         return ResponseEntity.ok("No sudden increase detected.");
+    //     }
+
+    //     return ResponseEntity.ok(warnings);
+    // }
+
+    @PostMapping("/pm25Increase")
+    public synchronized Warning processAirQualityInput(@RequestBody AirPollutionEvent event) {
+        // System.out.println("Received new air quality input: " + input.getTimestamp());
+        // System.out.println("REQUEST >> " + request);
+
+        // ubaci događaj u sesiju
+        // this.kSession.insert(input);
+
+        // for(Pollutant p : request.getMeasurement().getPollutants()) {
+        //     this.kSession.insert(p);
+        // }
+
+        long ts = System.currentTimeMillis();  // realtime test; bez ručnog timestamp-a
+
+        // debug log *posle* definicije ts
+        System.out.println(event);
+        System.out.println("REQ pm25=" + event.getPm25() + ", ts=" + ts + " windSpeed: " + event.getWindSpeed());
+
+        // ubaci događaj u ISTU sesiju
+        this.kSession.insert(new AirPollutionEvent(event.getPm25(), event.getPm10(), event.getNo2(),event.getWindSpeed(), ts, event.getUserEmail()));
+
+        // pokreni pravila
+        this.kSession.fireAllRules();
+        
+        User user = userRepository.findByEmail(event.getUserEmail())
+                .orElseThrow(() -> new RuntimeException("User not found with email: " + event.getUserEmail()));
+        
+        // prikupi sve Warning objekte koji su eventualno generisani
+        // List<Warning> warnings = new ArrayList<>();
+        // for (Object o : this.kSession.getObjects()) {
+        //     if (o instanceof Warning) {
+        //         Warning warning = (Warning) o;
+        //         warning.setUser(user);
+        //         warningRepository.save(warning);
+        //         warnings.add(warning);
+        //     }
+        // }
+
+        // if (warnings.isEmpty()) {
+        //     return ResponseEntity.ok("No sudden increase detected.");
+        // }
+
+        // return ResponseEntity.ok(warnings);
+
+        if(warning.getContent() != null){
+            Warning w = new Warning();
+            w.setContent(warning.getContent());
+            w.setTimestamp(LocalDateTime.now());
+            w.setUser(user);
+
+            warningRepository.save(w);
+
+            return w;
+        }
+        else{
+            return null;
+        }
+    }
+}

--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/CepController.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/CepController.java
@@ -1,0 +1,31 @@
+package com.ftn.controller;
+
+import com.ftn.model.*;
+import com.ftn.model.messages.GeneralMessage;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.KieServices;
+import org.springframework.web.bind.annotation.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/cep")
+@CrossOrigin(origins = "http://localhost:4200")
+public class CepController {
+
+    @PostMapping("/test-sudden-increase")
+    public String testSuddenIncrease(@RequestBody List<AirQualityInput> inputs) {
+        KieServices ks = KieServices.Factory.get();
+        KieSession kieSession = ks.getKieClasspathContainer().newKieSession("cep-ksession");
+
+        // Ubacujemo sve događaje
+        for (AirQualityInput input : inputs) {
+            kieSession.insert(input);
+        }
+
+        int fired = kieSession.fireAllRules();
+        kieSession.dispose();
+
+        return "CEP Rules triggered: " + fired;
+    }
+}

--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/WarningRepository.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/WarningRepository.java
@@ -1,0 +1,10 @@
+package com.ftn.service;
+
+import com.ftn.model.messages.Warning;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WarningRepository extends JpaRepository<Warning, Long> {
+    // Nema dodatnih metoda potrebnih za osnovne CRUD operacije
+}


### PR DESCRIPTION
Implemented real-time CEP rules for air quality monitoring: detects sudden PM2.5 spikes over 20 µg/m³ in the last 30 minutes and generates a “sudden pollution increase” warning; triggers alerts for institutions (e.g., schools and kindergartens) if air remains hazardous for more than 6 consecutive hours; adds recommendations for prolonged smog retention when wind is weak and PM2.5 stays above 55 µg/m³ for 12 hours.