### PR TITLE
Bacward rules

### DIFF
--- a/Kvalitet_vazduha/kjar/src/main/resources/META-INF/kmodule.xml
+++ b/Kvalitet_vazduha/kjar/src/main/resources/META-INF/kmodule.xml
@@ -17,4 +17,12 @@
     <kbase name="rulesNewCEP" packages="rules/cepRules" eventProcessingMode="stream">
         <ksession name="k-session-new-cep" type="stateful" clockType="realtime"/>
     </kbase>
+
+    <kbase name="backward-hazardous-quality-kbase" packages="backward">
+        <ksession name="backward-hazardous-quality-ksession"/>
+    </kbase>
+
+    <kbase name="backward-mask-kbase" packages="backwardMask">
+        <ksession name="backward-mask-ksession"/>
+    </kbase>
 </kmodule>

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/META-INF/kmodule.xml
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/META-INF/kmodule.xml
@@ -19,4 +19,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <kbase name="basicRules" packages="rules/basicRules">
         <ksession name="basic-ksession"/>
     </kbase>
+
+    <kbase name="backward-hazardous-quality-kbase" packages="rules/backward">
+        <ksession name="backward-hazardous-quality-ksession"/>
+    </kbase>
+
+    <kbase name="backward-mask-kbase" packages="rules/backwardMask">
+        <ksession name="backward-mask-ksession"/>
+    </kbase>
 </kmodule>

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/backward/air-backwrad-rules.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/backward/air-backwrad-rules.drl
@@ -30,40 +30,22 @@
 //     // --- ROOT: izdati upozorenje (opasan) ---
 //     // tražimo: (SeverePollution OR MultiPollutantHigh) AND (UnfavorableWeather) 
 //     // i po mogućnosti SensitiveUser za jače preporuke
-//     insert( new HypothesisDependency(
-//         "IssueAlertOpasan",
-//         Arrays.asList("OverallStatusOpasan", "UnfavorableWeather")
-//     ) );
+//     insert( new HypothesisDependency( "IssueAlertOpasan", Arrays.asList("OverallStatusOpasan", "UnfavorableWeather")) );
 
 //     // Za personalizovanu eskalaciju: root+SensitiveUser => "StrongProtectAdvice"
-//     insert( new HypothesisDependency(
-//         "StrongProtectAdvice",
-//         Arrays.asList("IssueAlertOpasan", "SensitiveUser")
-//     ) );
+//     insert( new HypothesisDependency( "StrongProtectAdvice", Arrays.asList("IssueAlertOpasan", "SensitiveUser") ) );
 
 //     // --- “Opasan” status izvođen iz polutanata ---
-//     insert( new HypothesisDependency(
-//         "OverallStatusOpasan",
-//         Arrays.asList("SeverePollution") // ili "MultiPollutantHigh"
-//     ) );
+//     insert( new HypothesisDependency( "OverallStatusOpasan", Arrays.asList("SeverePollution") ) );
 
 //     // Jedan jako visok polutant dovoljan
-//     insert( new HypothesisDependency(
-//         "SeverePollution",
-//         Arrays.asList("PM25_Opasan_OR_PM10_Opasan_OR_NO2_Opasan_OR_O3_Opasan")
-//     ) );
+//     insert( new HypothesisDependency( "SeverePollution", Arrays.asList("PM25_Opasan_OR_PM10_Opasan_OR_NO2_Opasan_OR_O3_Opasan") ) );
 
 //     // Vremenski uslovi koji pogoršavaju disperziju
-//     insert( new HypothesisDependency(
-//         "UnfavorableWeather",
-//         Arrays.asList("LowWind_OR_NoPrecip")
-//     ) );
+//     insert( new HypothesisDependency( "UnfavorableWeather",  Arrays.asList("LowWind_OR_NoPrecip") ) );
 
 //     // --- Sensitive user (profil) ---
-//     insert( new HypothesisDependency(
-//         "SensitiveUser",
-//         Arrays.asList("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant")
-//     ) );
+//     insert( new HypothesisDependency( "SensitiveUser", Arrays.asList("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant") ) );
 // end
 
 // // =====================================================================

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/backward/backward-hazardous-quality.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/backward/backward-hazardous-quality.drl
@@ -1,0 +1,155 @@
+package rules.backward
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.ftn.model.AirPollutionEvent;
+import com.ftn.model.AirQualityStatus;
+import com.ftn.model.AirQualityCategory;
+import com.ftn.model.UserProfile;
+import com.ftn.model.UserCategory;
+import com.ftn.model.*;
+import com.ftn.dto.*;
+
+// =====================================================================
+declare HypothesisDependency
+    conclusion     : String
+    prerequisites  : java.util.List
+end
+
+// =====================================================================
+// Inicijalizacija stabla zavisnosti za "Opasan vazduh" i preporuke
+// Root hipoteza: "IssueAlertOpasan" (izdati upozorenje: OPASAN)
+// Slojevi niže: kombinacije polutanata + vremenskih uslova + profila
+// =====================================================================
+rule "Init dependencies for Air Quality backward"
+salience 100
+when
+    not( HypothesisDependency() )
+then
+    System.out.println(">> Init backward dependencies for Air Quality...");
+
+    // --- ROOT: izdati upozorenje (opasan) ---
+    // tražimo: (SeverePollution OR MultiPollutantHigh) AND (UnfavorableWeather) 
+    // i po mogućnosti SensitiveUser za jače preporuke
+    insert( new HypothesisDependency( "IssueAlertHazardous", Arrays.asList("OverallStatusHazardous", "UnfavorableWeather")) );
+
+    // Za personalizovanu eskalaciju: root+SensitiveUser => "StrongProtectAdvice"
+    insert( new HypothesisDependency( "StrongProtectAdvice", Arrays.asList("IssueAlertHazardous", "SensitiveUser") ) );
+
+    // --- “Opasan” status izvođen iz polutanata ---
+    insert( new HypothesisDependency( "OverallStatusHazardous", Arrays.asList("SeverePollution") ) );
+
+    // Jedan jako visok polutant dovoljan
+    insert( new HypothesisDependency( "SeverePollution", Arrays.asList("PM25_Hazardous_OR_PM10_Hazardous_OR_NO2_Hazardous_OR_O3_Hazardous") ) );
+
+    // Vremenski uslovi koji pogoršavaju disperziju
+    insert( new HypothesisDependency( "UnfavorableWeather",  Arrays.asList("LowWind_OR_NoPrecip") ) );
+
+    // --- Sensitive user (profil) ---
+    insert( new HypothesisDependency( "SensitiveUser", Arrays.asList("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant") ) );
+end
+
+// =====================================================================
+// REKURZIVNA PROVERA: bazni dokazi su direktno iz činjenica (fakta)
+// ili se hipoteza dokazuje tako što su sve njene pretpostavke dokazane.
+// =====================================================================
+query proveHypothesis(String $h)
+    // -------------------- Bazni (atomarni) uslovi --------------------
+    // POLUTANTI – pragovi iz specifikacije (PM2.5 / PM10 ± ekvivalenti)
+    (
+        // PM2.5
+        ( eval($h.equals("PM25_Hazardous")) and exists AirPollutionEvent( pm25 > 55 ) ) or
+        ( eval($h.equals("PM25_Poor"))    and exists AirPollutionEvent( pm25 > 35, pm25 <= 55 ) ) or
+        ( eval($h.equals("PM25_Moderate")) and exists AirPollutionEvent( pm25 > 15, pm25 <= 35 ) ) or
+        ( eval($h.equals("PM25_Good"))  and exists AirPollutionEvent( pm25 <= 15 ) ) or
+
+        // PM10
+        ( eval($h.equals("PM10_Hazardous")) and exists AirPollutionEvent( pm10 > 100 ) ) or
+        ( eval($h.equals("PM10_Poor"))    and exists AirPollutionEvent( pm10 > 50,  pm10 <= 100 ) ) or
+        ( eval($h.equals("PM10_Moderate")) and exists AirPollutionEvent( pm10 > 25,  pm10 <= 50 ) ) or
+        ( eval($h.equals("PM10_Good"))  and exists AirPollutionEvent( pm10 <= 25 ) ) or
+
+        // NO2
+        ( eval($h.equals("NO2_Hazardous"))  and exists AirPollutionEvent( no2 > 180 ) ) or
+        ( eval($h.equals("NO2_Poor"))  and exists AirPollutionEvent( no2 > 90, no2 <= 180 ) ) or
+        ( eval($h.equals("NO2_Moderate"))  and exists AirPollutionEvent( no2 > 40, no2 <= 90  ) ) or
+        ( eval($h.equals("NO2_Good"))  and exists AirPollutionEvent( no2 <= 40 ) ) or
+
+        // O3
+        ( eval($h.equals("O3_Hazardous"))   and exists AirPollutionEvent( o3  > 180 ) ) or
+        ( eval($h.equals("O3_Poor"))   and exists AirPollutionEvent( o3  > 140, o3 <= 180 ) ) or
+        ( eval($h.equals("O3_Moderate"))   and exists AirPollutionEvent( o3  > 100, o3 <=  140 ) ) or
+        ( eval($h.equals("O3_Good"))   and exists AirPollutionEvent( o3  <= 100 ) ) or
+
+        // Agregati baznih polutanata kao “OR” čvorovi
+        ( eval($h.equals("PM25_Hazardous_OR_PM10_Hazardous_OR_NO2_Hazardous_OR_O3_Hazardous"))
+              and ( exists AirPollutionEvent( pm25 > 55 ) 
+                 or exists AirPollutionEvent( pm10 > 100 )
+                 or exists AirPollutionEvent( no2  > 200 )
+                 or exists AirPollutionEvent( o3   > 180 ) ) ) or
+
+        // Vreme
+        ( eval($h.equals("LowWind"))     and exists AirPollutionEvent( windSpeed < 1.5 ) ) or
+        ( eval($h.equals("NoPrecip"))    and exists AirPollutionEvent( precipitation == false ) ) or
+        ( eval($h.equals("LowWind_OR_NoPrecip"))
+              and ( exists AirPollutionEvent( windSpeed < 1.5 )
+                 or exists AirPollutionEvent( precipitation == false ) ) ) or
+
+        // Profil korisnika (oslanja se na tvoju klasu UserProfile/UserCategory)
+        ( eval($h.equals("IsChild"))     and exists User( riskType == RiskType.CHILD ) ) or
+        ( eval($h.equals("IsElderly"))   and exists User( riskType == RiskType.ELDERLY ) ) or
+        ( eval($h.equals("IsChronic"))   and exists User( riskType == RiskType.CHRONIC ) ) or
+        ( eval($h.equals("IsPregnant"))  and exists User( riskType == RiskType.PREGNANT ) ) or
+        ( eval($h.equals("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant"))
+              and exists User( riskType in (RiskType.CHILD, RiskType.ELDERLY, RiskType.CHRONIC, RiskType.PREGNANT) ) )
+    )
+    or
+    // -------------------- Rekurzivni korak ---------------------------
+    (
+        $z : HypothesisDependency( conclusion == $h )
+        and not(
+            String($p: this) from $z.prerequisites
+            and
+            not proveHypothesis($p;)
+        )
+    )
+end
+
+// =====================================================================
+// Završna pravila: kad se hipoteze dokažu, upiši status + objašnjenje
+// =====================================================================
+
+// OPASAN – opšte upozorenje
+rule "Confirm OPASAN via backward reasoning"
+salience 10
+no-loop true
+when
+    proveHypothesis("IssueAlertHazardous";)
+    // $status : AirQualityStatus()
+    $result : BackwardReasoningResult()
+then
+    System.out.println(">> OPASAN (backward): visoki polutanti + nepovoljno vreme");
+    // $status.setCategory(AirQualityCategory.OPASAN);
+    $result.setHazardous(true);
+    $result.setExplanation(">> HAZARDOUS: high pollutants + unfavorable weather");
+    // $status.setExplanation("Dokazano rekurzivno: (SeverePollution OR MultiPollutantHigh) i nepovoljno vreme.");
+    // $status.setRecommendation("Ostanite u zatvorenom; koristite P2/P3 maske; izbegavajte napor napolju.");
+    // update($status);
+end
+
+// OPASAN + rizične grupe – jača poruka
+rule "Personalized strong advice for sensitive users"
+salience 9
+no-loop true
+when
+    proveHypothesis("StrongProtectAdvice";)
+    $result : BackwardReasoningResult()
+    // $status : AirQualityStatus( category == AirQualityCategory.OPASAN )
+then
+    System.out.println(">> OPASAN (sensitive): posebne preporuke");
+    $result.setStrongProtectAdvice(true);
+    $result.setRecommendation("Especially for risk groups: avoid going out; consult a doctor if symptoms occur.");
+    // $status.setRecommendation($status.getRecommendation() + " Posebno za rizične grupe: izbegavati izlazak; konsultovati lekara ako se jave simptomi.");
+    // update($status);
+end

--- a/Kvalitet_vazduha/kjar/src/main/resources/rules/bacwardMask/backward-mask.drl
+++ b/Kvalitet_vazduha/kjar/src/main/resources/rules/bacwardMask/backward-mask.drl
@@ -1,0 +1,112 @@
+package rules.backwardMask
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.ftn.model.AirPollutionEvent;
+import com.ftn.model.User;
+import com.ftn.model.RiskType;
+import com.ftn.dto.*;
+
+// =====================================================================
+declare HypothesisDependency
+    conclusion     : String
+    prerequisites  : java.util.List
+end
+
+// =====================================================================
+// Inicijalizacija stabla zavisnosti za "ShouldWearMask"
+// =====================================================================
+rule "Init dependencies for Mask Recommendation backward"
+salience 100
+when
+    not( HypothesisDependency() )
+then
+    System.out.println(">> Init backward dependencies for Mask Recommendation...");
+
+    // Glavni zaključak: korisnik treba da nosi masku
+    insert( new HypothesisDependency("ShouldWearMask", Arrays.asList("PollutionHighOrWorse", "LowWind")) );
+
+    // Ako je korisnik rizičan + treba nositi masku → preporuka za jaču zaštitu
+    insert( new HypothesisDependency("StrongMaskAdvice", Arrays.asList("ShouldWearMask", "SensitiveUser")) );
+
+    // Povišeno zagađenje – "loš" ili "opasan"
+    insert( new HypothesisDependency("PollutionHighOrWorse", Arrays.asList("PM25_High_OR_PM10_High_OR_NO2_High_OR_O3_High")) );
+
+    // Rizičan korisnik
+    insert( new HypothesisDependency("SensitiveUser", Arrays.asList("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant")) );
+end
+
+// =====================================================================
+// BAZNI USLOVI + rekurzivna provera
+// =====================================================================
+query proveMask(String $h)
+    (
+        // PM2.5
+        ( eval($h.equals("PM25_High")) and exists AirPollutionEvent( pm25 > 35 ) ) or
+        // PM10
+        ( eval($h.equals("PM10_High")) and exists AirPollutionEvent( pm10 > 50 ) ) or
+        // NO2
+        ( eval($h.equals("NO2_High")) and exists AirPollutionEvent( no2 > 100 ) ) or
+        // O3
+        ( eval($h.equals("O3_High")) and exists AirPollutionEvent( o3 > 140 ) ) or
+
+        // Kombinovani OR za visok nivo bilo kog polutanta
+        ( eval($h.equals("PM25_High_OR_PM10_High_OR_NO2_High_OR_O3_High")) and 
+            ( exists AirPollutionEvent( pm25 > 35 ) or
+              exists AirPollutionEvent( pm10 > 50 ) or
+              exists AirPollutionEvent( no2 > 100 ) or
+              exists AirPollutionEvent( o3 > 140 ) ) ) or
+
+        // Slab vetar
+        ( eval($h.equals("LowWind")) and exists AirPollutionEvent( windSpeed < 2.0 ) ) or
+
+        // Profil korisnika
+        ( eval($h.equals("IsChild"))    and exists User( riskType == RiskType.CHILD ) ) or
+        ( eval($h.equals("IsElderly"))  and exists User( riskType == RiskType.ELDERLY ) ) or
+        ( eval($h.equals("IsChronic"))  and exists User( riskType == RiskType.CHRONIC ) ) or
+        ( eval($h.equals("IsPregnant")) and exists User( riskType == RiskType.PREGNANT ) ) or
+        ( eval($h.equals("IsChild_OR_Elderly_OR_Chronic_OR_Pregnant")) and 
+            exists User( riskType in (RiskType.CHILD, RiskType.ELDERLY, RiskType.CHRONIC, RiskType.PREGNANT) ) )
+    )
+    or
+    (
+        $z : HypothesisDependency( conclusion == $h )
+        and not(
+            String($p: this) from $z.prerequisites
+            and not proveMask($p;)
+        )
+    )
+end
+
+// =====================================================================
+// ZAKLJUČCI
+// =====================================================================
+
+// Preporuka za nošenje maske
+rule "Confirm mask recommendation via backward reasoning"
+salience 10
+no-loop true
+when
+    proveMask("ShouldWearMask";)
+    $mask : MaskRecommendationResponse()
+then
+    System.out.println(">> PREPORUKA: KORISNIK TREBA DA NOSI MASKU (povišeno zagađenje + slab vetar).");
+    $mask.setShouldWearMask(true);
+    $mask.setMessage(">> RECOMMENDATION: You need to wear a mask!");
+    update($mask);
+end
+
+// Jača preporuka za rizične korisnike
+rule "Stronger mask advice for sensitive users"
+salience 9
+no-loop true
+when
+    proveMask("StrongMaskAdvice";)
+    $mask : MaskRecommendationResponse()
+then
+    System.out.println(">> POSEBNO ZA RIZIČNE GRUPE: OBAVEZNO NOŠENJE P2/P3 MASKE NA OTVORENOM.");
+    $mask.setStrongAdvice(true);
+    $mask.setRiskMessage(">> ESPECIALLY FOR RISK GROUPS: MANDATORY WEARING OF P2/P3 MASK OUTDOORS.");
+    update($mask);
+end

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/dto/BackwardReasoningResult.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/dto/BackwardReasoningResult.java
@@ -1,0 +1,68 @@
+package com.ftn.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BackwardReasoningResult {
+
+    private boolean isHazardous;
+    private boolean strongProtectAdvice;
+    private String explanation;          
+    private String recommendation;
+
+    public BackwardReasoningResult() {
+    }
+
+    // Konstruktor sa svim parametrima
+    public BackwardReasoningResult(boolean isHazardous, boolean strongProtectAdvice, String explanation, String recommendation) {
+        this.isHazardous = isHazardous;
+        this.strongProtectAdvice = strongProtectAdvice;
+        this.explanation = explanation;
+        this.recommendation = recommendation;
+    }
+
+    // ======================= Getteri i Setteri =======================
+
+    public boolean isHazardous() {
+        return isHazardous;
+    }
+
+    public void setHazardous(boolean isHazardous) {
+        this.isHazardous = isHazardous;
+    }
+
+    public boolean isStrongProtectAdvice() {
+        return strongProtectAdvice;
+    }
+
+    public void setStrongProtectAdvice(boolean strongProtectAdvice) {
+        this.strongProtectAdvice = strongProtectAdvice;
+    }
+
+    public String getExplanation() {
+        return explanation;
+    }
+
+    public void setExplanation(String explanation) {
+        this.explanation = explanation;
+    }
+
+    public String getRecommendation() {
+        return recommendation;
+    }
+
+    public void setRecommendation(String recommendation) {
+        this.recommendation = recommendation;
+    }
+
+    @Override
+    public String toString() {
+        return "BackwardReasoningResult{" +
+                "isHazardous=" + isHazardous +
+                ", strongProtectAdvice=" + strongProtectAdvice +
+                ", explanation='" + explanation + '\'' +
+                ", recommendation='" + recommendation + '\'' +
+                '}';
+    }
+    
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/dto/MaskRecommendationResponse.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/dto/MaskRecommendationResponse.java
@@ -1,0 +1,53 @@
+package com.ftn.dto;
+
+import java.util.List;
+
+public class MaskRecommendationResponse {
+
+    private boolean shouldWearMask;
+    private boolean strongAdvice;
+    private String message;
+    private String riskMessage;
+
+    public MaskRecommendationResponse() {}
+
+    public MaskRecommendationResponse(boolean shouldWearMask, boolean strongAdvice, String message, String riskMessage) {
+        this.shouldWearMask = shouldWearMask;
+        this.strongAdvice = strongAdvice;
+        this.message = message;
+        this.riskMessage = riskMessage;
+    }
+
+    public boolean isShouldWearMask() {
+        return shouldWearMask;
+    }
+
+    public void setShouldWearMask(boolean shouldWearMask) {
+        this.shouldWearMask = shouldWearMask;
+    }
+
+    public boolean isStrongAdvice() {
+        return strongAdvice;
+    }
+
+    public void setStrongAdvice(boolean strongAdvice) {
+        this.strongAdvice = strongAdvice;
+    }
+
+    public String getMessage() {   
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getRsikMessage() {   
+        return riskMessage;
+    }
+
+    public void setRiskMessage(String riskMessage) {
+        this.riskMessage = riskMessage;
+    }
+
+}

--- a/Kvalitet_vazduha/model/src/main/java/com/ftn/model/BackwardQualityRequest.java
+++ b/Kvalitet_vazduha/model/src/main/java/com/ftn/model/BackwardQualityRequest.java
@@ -1,0 +1,13 @@
+package com.ftn.model;
+
+import com.ftn.model.UserCategory;
+
+public class BackwardQualityRequest {
+    public double pm25;
+    public double pm10;
+    public double no2;
+    public double o3;
+    public double windSpeed;
+    public boolean precipitation;
+    public String userEmail;
+}

--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/BackwardController.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/BackwardController.java
@@ -10,6 +10,9 @@ import com.ftn.model.BackwardEvalRequest;
 import com.ftn.model.AirPollutionEvent;
 import com.ftn.model.AirQualityStatus;
 import com.ftn.model.UserProfile;
+import com.ftn.model.*;
+import com.ftn.dto.*;
+import com.ftn.service.UserRepository;
 
 @RestController
 @RequestMapping("/api/backward")
@@ -17,14 +20,50 @@ public class BackwardController {
 
     private final KieContainer kieContainer;
 
-    public BackwardController(KieContainer kieContainer) {
+    private final UserRepository userRepository;
+
+    public BackwardController(KieContainer kieContainer, UserRepository userRepository) {
         this.kieContainer = kieContainer;
+        this.userRepository = userRepository;
     }
 
-    @PostMapping("/evaluate")
-    public ResponseEntity<AirQualityStatus> evaluate(@RequestBody BackwardEvalRequest req) {
+    // @PostMapping("/evaluate")
+    // public ResponseEntity<AirQualityStatus> evaluate(@RequestBody BackwardEvalRequest req) {
 
-        KieSession ks = kieContainer.newKieSession("backward-ksession"); // ili ime ako koristiš named-session iz kmodule.xml
+    //     KieSession ks = kieContainer.newKieSession("backward-ksession"); // ili ime ako koristiš named-session iz kmodule.xml
+
+    //     try {
+    //         // 1) Činjenice
+    //         System.out.println(req);
+    //         AirPollutionEvent e = new AirPollutionEvent();
+    //         e.setPm25(req.pm25);
+    //         e.setPm10(req.pm10);
+    //         e.setNo2(req.no2);
+    //         e.setO3(req.o3);
+    //         e.setWindSpeed(req.windSpeed);
+    //         e.setPrecipitation(req.precipitation);
+    //         ks.insert(e);
+
+    //         UserProfile up = new UserProfile();
+    //         up.setUserType(req.userCategory);
+    //         ks.insert(up);
+
+    //         AirQualityStatus status = new AirQualityStatus();
+    //         ks.insert(status);
+
+    //         // 2) Pali pravila
+    //         ks.fireAllRules();
+
+    //         return ResponseEntity.ok(status);
+    //     } finally {
+    //         ks.dispose();
+    //     }
+    // }
+
+    @PostMapping("/evaluate")
+    public ResponseEntity<?> evaluate(@RequestBody BackwardQualityRequest req) {
+
+        KieSession ks = kieContainer.newKieSession("backward-hazardous-quality-ksession"); // ili ime ako koristiš named-session iz kmodule.xml
 
         try {
             // 1) Činjenice
@@ -38,17 +77,54 @@ public class BackwardController {
             e.setPrecipitation(req.precipitation);
             ks.insert(e);
 
-            UserProfile up = new UserProfile();
-            up.setUserType(req.userCategory);
-            ks.insert(up);
+            User user = userRepository.findByEmail(req.userEmail)
+                .orElseThrow(() -> new RuntimeException("User not found with email: " + req.userEmail));
+            ks.insert(user);
 
-            AirQualityStatus status = new AirQualityStatus();
-            ks.insert(status);
+            // AirQualityStatus status = new AirQualityStatus();
+            // ks.insert(status)
+            BackwardReasoningResult br = new BackwardReasoningResult();
+            ks.insert(br);
 
             // 2) Pali pravila
             ks.fireAllRules();
 
-            return ResponseEntity.ok(status);
+            return ResponseEntity.ok(br);
+        } finally {
+            ks.dispose();
+        }
+    }
+
+    @PostMapping("/mask")
+    public ResponseEntity<?> mask(@RequestBody BackwardQualityRequest req) {
+
+        KieSession ks = kieContainer.newKieSession("backward-mask-ksession"); // ili ime ako koristiš named-session iz kmodule.xml
+
+        try {
+            // 1) Činjenice
+            System.out.println(req);
+            AirPollutionEvent e = new AirPollutionEvent();
+            e.setPm25(req.pm25);
+            e.setPm10(req.pm10);
+            e.setNo2(req.no2);
+            e.setO3(req.o3);
+            e.setWindSpeed(req.windSpeed);
+            e.setPrecipitation(req.precipitation);
+            ks.insert(e);
+
+            User user = userRepository.findByEmail(req.userEmail)
+                .orElseThrow(() -> new RuntimeException("User not found with email: " + req.userEmail));
+            ks.insert(user);
+
+            // AirQualityStatus status = new AirQualityStatus();
+            // ks.insert(status);
+            MaskRecommendationResponse mr = new MaskRecommendationResponse();
+            ks.insert(mr);
+
+            // 2) Pali pravila
+            ks.fireAllRules();
+
+            return ResponseEntity.ok(mr);
         } finally {
             ks.dispose();
         }


### PR DESCRIPTION
Implemented backward reasoning rules for air quality alerts: added a general "Hazardous" alert based on high pollutant levels and unfavorable weather conditions, and a personalized "StrongProtectAdvice" for sensitive user groups. The rules recursively evaluate pollutant thresholds, weather factors, and user risk profiles to determine hazard status and generate appropriate recommendations. This update enables the system to provide both general warnings and targeted advice for vulnerable populations.