### PR TITLE
Backward: front

### DIFF
--- a/Kvalitet_vazduha/service/src/main/java/com/ftn/service/BackwardController.java
+++ b/Kvalitet_vazduha/service/src/main/java/com/ftn/service/BackwardController.java
@@ -16,6 +16,7 @@ import com.ftn.service.UserRepository;
 
 @RestController
 @RequestMapping("/api/backward")
+@CrossOrigin(origins = "http://localhost:4200")
 public class BackwardController {
 
     private final KieContainer kieContainer;

--- a/air-quality-app/src/app/app.routes.ts
+++ b/air-quality-app/src/app/app.routes.ts
@@ -5,13 +5,15 @@ import { DashboardComponent } from './dashboard/dashboard/dashboard.component';
 import { AppComponent } from './app.component';
 import { NgModule } from '@angular/core';
 import { WarningsComponent } from './warnings/warnings.component';
+import { RecommendationsComponent } from './recommendations/recommendations.component';
 
 export const routes: Routes = [
     { path: '', component: RegisterComponent },
     { path: 'login', component: LoginComponent },
     { path: 'register', component: RegisterComponent },
     { path: 'dashboard', component: DashboardComponent },
-    { path: 'warnings', component: WarningsComponent }
+    { path: 'warnings', component: WarningsComponent },
+    { path: 'recommendations', component: RecommendationsComponent }
 ];
 
 @NgModule({

--- a/air-quality-app/src/app/models/backward-quality.model.ts
+++ b/air-quality-app/src/app/models/backward-quality.model.ts
@@ -1,0 +1,9 @@
+export interface BackwardQualityRequest {
+  pm25: number;
+  pm10: number;
+  no2: number;
+  o3: number;
+  windSpeed: number;
+  precipitation: boolean;
+  userEmail: string;
+}

--- a/air-quality-app/src/app/models/backward-reasoning-result.model.ts
+++ b/air-quality-app/src/app/models/backward-reasoning-result.model.ts
@@ -1,0 +1,6 @@
+export interface BackwardReasoningResult {
+  hazardous: boolean;
+  strongProtectAdvice: boolean;
+  explanation: string;
+  recommendation: string;
+}

--- a/air-quality-app/src/app/models/mask-recommendation-response.model.ts
+++ b/air-quality-app/src/app/models/mask-recommendation-response.model.ts
@@ -1,0 +1,6 @@
+export interface MaskRecommendationResponse {
+  shouldWearMask: boolean;
+  strongAdvice: boolean;
+  message: string;
+  rsikMessage: string;
+}

--- a/air-quality-app/src/app/navigation/navigation/navigation.component.html
+++ b/air-quality-app/src/app/navigation/navigation/navigation.component.html
@@ -8,8 +8,8 @@
 
   <ul class="dropdown" *ngIf="menuOpen">
     <li><a (click)="openDashboard()">Dashboard</a></li>
-    <li><a routerLink="/details">Details</a></li>
-    <li><a routerLink="/history">History</a></li>
     <li><a (click)="openWarnings()">Warnings</a></li>
+    <li><a (click)="openRecommendations()">Recommendations</a></li>
+    <li><a routerLink="/history">Template</a></li>
   </ul>
 </nav>

--- a/air-quality-app/src/app/navigation/navigation/navigation.component.ts
+++ b/air-quality-app/src/app/navigation/navigation/navigation.component.ts
@@ -25,4 +25,8 @@ export class NavigationComponent {
   openWarnings(){
     this.router.navigate(['/warnings']);
   }
+
+  openRecommendations(){
+    this.router.navigate(['/recommendations']);
+  }
 }

--- a/air-quality-app/src/app/recommendations/recommendations.component.css
+++ b/air-quality-app/src/app/recommendations/recommendations.component.css
@@ -1,0 +1,84 @@
+.container {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  background: #f7f9fc;
+  border-radius: 12px;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+h1 {
+  text-align: center;
+  color: #2c3e50;
+  margin-bottom: 2rem;
+}
+
+.pollutant-table-container h2 {
+  color: #34495e;
+  margin-bottom: 1rem;
+}
+
+.pollutant-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 2rem;
+}
+
+.pollutant-table th, .pollutant-table td {
+  padding: 0.75rem 1rem;
+  border: 1px solid #dfe6e9;
+  text-align: center;
+}
+
+.pollutant-table th {
+  background-color: #74b9ff;
+  color: #fff;
+  font-weight: 600;
+}
+
+.pollutant-table tbody tr:nth-child(even) {
+  background-color: #dfe6e9;
+}
+
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.action button {
+  padding: 0.8rem 1.5rem;
+  font-size: 1rem;
+  background-color: #0984e3;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.action button:hover {
+  background-color: #74b9ff;
+}
+
+.result {
+  margin-top: 0.5rem;
+  padding: 1rem;
+  border-left: 4px solid #0984e3;
+  background-color: #dfe6e9;
+  border-radius: 6px;
+}
+
+.result strong {
+  display: block;
+  font-size: 1.1rem;
+  margin-bottom: 0.3rem;
+  color: #2d3436;
+}
+
+.result p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #2d3436;
+}

--- a/air-quality-app/src/app/recommendations/recommendations.component.html
+++ b/air-quality-app/src/app/recommendations/recommendations.component.html
@@ -1,0 +1,99 @@
+<!-- <app-navigation></app-navigation>
+<div class="container">
+  <h1>Air Quality Backward Analysis</h1>
+
+  <div class="pollutant-table-container">
+    <h2>Current Pollutant Values</h2>
+    <table class="pollutant-table">
+      <thead>
+        <tr>
+          <th>Pollutant</th>
+          <th>PM2.5 (µg/m³)</th>
+          <th>PM10 (µg/m³)</th>
+          <th>NO₂ (µg/m³)</th>
+          <th>O₃ (µg/m³)</th>
+          <th>Wind Speed (m/s)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Value</td>
+          <td>{{pollutants.pm25}}</td>
+          <td>{{pollutants.pm10}}</td>
+          <td>{{pollutants.no2}}</td>
+          <td>{{pollutants.o3}}</td>
+          <td>{{pollutants.windSpeed}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="action-buttons">
+    <div class="action">
+      <button (click)="checkSafety()">Is it safe to go outside?</button>
+      <div class="result" *ngIf="safetyResult">
+        <strong>{{ safetyResult.isSafe ? 'SAFE' : 'NOT SAFE' }}</strong>
+        <p>{{ safetyResult.message }}</p>
+      </div>
+    </div>
+
+    <div class="action">
+      <button (click)="checkMask()">Do I need to wear a mask?</button>
+      <div class="result" *ngIf="maskResult">
+        <strong>{{ maskResult.isRequired ? 'MASK REQUIRED' : 'MASK NOT REQUIRED' }}</strong>
+        <p>{{ maskResult.message }}</p>
+      </div>
+    </div>
+  </div>
+</div> -->
+
+<app-navigation></app-navigation>
+<div class="container">
+  <h1>Air Quality Backward Analysis</h1>
+
+  <div class="pollutant-table-container">
+    <h2>Current Pollutant Values</h2>
+    <table class="pollutant-table">
+      <thead>
+        <tr>
+          <th>Pollutant</th>
+          <th>PM2.5 (µg/m³)</th>
+          <th>PM10 (µg/m³)</th>
+          <th>NO₂ (µg/m³)</th>
+          <th>O₃ (µg/m³)</th>
+          <th>Wind Speed (m/s)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Value</td>
+          <td>{{pollutants.pm25}}</td>
+          <td>{{pollutants.pm10}}</td>
+          <td>{{pollutants.no2}}</td>
+          <td>{{pollutants.o3}}</td>
+          <td>{{pollutants.windSpeed}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="action-buttons">
+    <div class="action">
+      <button (click)="checkSafety()">Is it safe to go outside?</button>
+      <div class="result" *ngIf="safetyResult">
+        <strong>{{ safetyResult.hazardous ? 'NOT SAFE' : 'SAFE' }}</strong>
+        <p><b>Explanation:</b> {{ safetyResult.explanation }}</p>
+        <p><b>Recommendation:</b> {{ safetyResult.recommendation }}</p>
+      </div>
+    </div>
+
+    <div class="action">
+      <button (click)="checkMask()">Do I need to wear a mask?</button>
+      <div class="result" *ngIf="maskResult">
+        <strong>{{ maskResult.shouldWearMask ? 'MASK REQUIRED' : 'MASK NOT REQUIRED' }}</strong>
+        <p><b>Message:</b> {{ maskResult.message }}</p>
+        <p><b>Risk Message:</b> {{ maskResult.rsikMessage }}</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/air-quality-app/src/app/recommendations/recommendations.component.spec.ts
+++ b/air-quality-app/src/app/recommendations/recommendations.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecommendationsComponent } from './recommendations.component';
+
+describe('RecommendationsComponent', () => {
+  let component: RecommendationsComponent;
+  let fixture: ComponentFixture<RecommendationsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RecommendationsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RecommendationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/air-quality-app/src/app/recommendations/recommendations.component.ts
+++ b/air-quality-app/src/app/recommendations/recommendations.component.ts
@@ -1,0 +1,105 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { NavigationComponent } from '../navigation/navigation/navigation.component';
+import { BackwardReasoningResult } from '../models/backward-reasoning-result.model';
+import { MaskRecommendationResponse } from '../models/mask-recommendation-response.model';
+import { BackwardAnalysisService } from '../service/backward-analysis.service';
+import { BackwardQualityRequest } from '../models/backward-quality.model';
+
+interface Pollutants {
+  pm25: number;
+  pm10: number;
+  no2: number;
+  o3: number;
+  windSpeed: number;
+  precipitation: boolean;
+}
+
+@Component({
+  selector: 'app-recommendations',
+  imports: [CommonModule, NavigationComponent],
+  templateUrl: './recommendations.component.html',
+  styleUrl: './recommendations.component.css'
+})
+export class RecommendationsComponent implements OnInit{
+  pollutants: Pollutants = {
+    pm25: 60,
+    pm10: 110,
+    no2: 210,
+    o3: 190,
+    windSpeed: 1.0,
+    precipitation: false
+  };
+
+  safetyResult: BackwardReasoningResult | null = null;
+  maskResult: MaskRecommendationResponse | null = null;
+
+  userEmail: string | null = '';
+
+  constructor(private backwardService: BackwardAnalysisService) {}
+
+  ngOnInit(): void {
+    if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
+      const userStr = localStorage.getItem('user');
+      if (userStr) {
+        const userObj = JSON.parse(userStr);
+        this.userEmail = userObj.email || '';
+        console.log("Korisnik:", userObj.email);
+      } else {
+        console.log("Nema korisnika u localStorage");
+      }
+    } else {
+      console.warn("localStorage nije dostupan u ovom okruženju");
+    }
+  }
+
+  private randomizePollutants(): void {
+    this.pollutants = {
+      pm25: this.randomInRange(36, 80),     // uvek veće od 35
+      pm10: this.randomInRange(55, 150),    // uvek veće od 50
+      no2: this.randomInRange(110, 250),    // uvek veće od 100
+      o3: this.randomInRange(150, 220),     // uvek veće od 140
+      windSpeed: this.randomInRange(1.0, 2.0),
+      precipitation: Math.random() < 0.5    // true/false nasumično
+    };
+  }
+
+  private randomInRange(min: number, max: number): number {
+    return Math.round((Math.random() * (max - min) + min) * 10) / 10;
+  }
+
+  checkSafety() {
+    const req: BackwardQualityRequest = {
+      ...this.pollutants,
+      userEmail: this.userEmail!
+    };
+
+    this.backwardService.evaluate(req).subscribe({
+      next: (res) => {
+        this.safetyResult = res;
+        console.log('Safety response:', res);
+      },
+      error: (err) => console.error('Error evaluating safety:', err)
+    });
+
+    this.randomizePollutants();
+  }
+
+  checkMask() {
+     const req: BackwardQualityRequest = {
+      ...this.pollutants,
+      userEmail: this.userEmail!
+    };
+
+    this.backwardService.mask(req).subscribe({
+      next: (res) => {
+        this.maskResult = res;
+        console.log('Mask response:', res);
+      },
+      error: (err) => console.error('Error getting mask recommendation:', err)
+    });
+
+      this.randomizePollutants();
+  }
+
+}

--- a/air-quality-app/src/app/service/backward-analysis.service.ts
+++ b/air-quality-app/src/app/service/backward-analysis.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  BackwardQualityRequest,
+} from '../models/backward-quality.model';
+import { BackwardReasoningResult } from '../models/backward-reasoning-result.model';
+import { MaskRecommendationResponse } from '../models/mask-recommendation-response.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BackwardAnalysisService {
+
+  private baseUrl = 'http://localhost:8090/api/backward'; // prilagodi ako koristiš drugačiji port/backend URL
+
+  constructor(private http: HttpClient) {}
+
+  evaluate(request: BackwardQualityRequest): Observable<BackwardReasoningResult> {
+    return this.http.post<BackwardReasoningResult>(`${this.baseUrl}/evaluate`, request);
+  }
+
+  mask(request: BackwardQualityRequest): Observable<MaskRecommendationResponse> {
+    return this.http.post<MaskRecommendationResponse>(`${this.baseUrl}/mask`, request);
+  }
+}


### PR DESCRIPTION
Implemented frontend integration for backward reasoning analysis. Added data models, service layer, and component logic to communicate with backend endpoints /api/backward/evaluate and /api/backward/mask. The component now dynamically sends current pollutant data and user information to the backend and displays personalized recommendations and explanations returned by the reasoning engine. This completes the functional connection between the frontend and Drools-based backward reasoning module.